### PR TITLE
feat : 카테고리 및 필터 구조 및 조회 구현

### DIFF
--- a/src/main/java/subscribenlike/mogupick/category/CategoryController.java
+++ b/src/main/java/subscribenlike/mogupick/category/CategoryController.java
@@ -31,7 +31,7 @@ public class CategoryController {
     @GetMapping("/options-filters")
     public ResponseEntity<SuccessResponse<List<CategoryOptionAndFilterResponse>>> getOptionsAndFilters(@RequestParam RootCategory rootCategory){
         return ResponseEntity
-                .status(CategorySuccessCode.ROOT_CATEGORIES_FETCHED.getStatus())
-                .body(SuccessResponse.from(CategorySuccessCode.ROOT_CATEGORIES_FETCHED,categoryService.getFiltersByRootCategoryAndOption(rootCategory)));
+                .status(CategorySuccessCode.CATEGORY_OPTIONS_AND_FILTERS_FETCHED.getStatus())
+                .body(SuccessResponse.from(CategorySuccessCode.CATEGORY_OPTIONS_AND_FILTERS_FETCHED,categoryService.getFiltersByRootCategoryAndOption(rootCategory)));
     }
 }

--- a/src/main/java/subscribenlike/mogupick/category/CategoryController.java
+++ b/src/main/java/subscribenlike/mogupick/category/CategoryController.java
@@ -1,0 +1,37 @@
+package subscribenlike.mogupick.category;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import subscribenlike.mogupick.category.common.sucess.CategorySuccessCode;
+import subscribenlike.mogupick.category.domain.RootCategory;
+import subscribenlike.mogupick.category.model.CategoryOptionAndFilterResponse;
+import subscribenlike.mogupick.category.model.RootCategoryResponse;
+import subscribenlike.mogupick.common.success.SuccessResponse;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/categories")
+@RequiredArgsConstructor
+public class CategoryController {
+    private final CategoryService categoryService;
+
+    @GetMapping("/root")
+    public ResponseEntity<SuccessResponse<List<RootCategoryResponse>>> getRootCategories(){
+        return ResponseEntity
+                .status(CategorySuccessCode.ROOT_CATEGORIES_FETCHED.getStatus())
+                .body(SuccessResponse.from(CategorySuccessCode.ROOT_CATEGORIES_FETCHED,categoryService.getRootCategories()));
+    }
+
+    @GetMapping("/options-filters")
+    public ResponseEntity<SuccessResponse<List<CategoryOptionAndFilterResponse>>> getOptionsAndFilters(@RequestParam RootCategory rootCategory){
+        return ResponseEntity
+                .status(CategorySuccessCode.ROOT_CATEGORIES_FETCHED.getStatus())
+                .body(SuccessResponse.from(CategorySuccessCode.ROOT_CATEGORIES_FETCHED,categoryService.getFiltersByRootCategoryAndOption(rootCategory)));
+    }
+}

--- a/src/main/java/subscribenlike/mogupick/category/CategoryOptionMappingGraph.java
+++ b/src/main/java/subscribenlike/mogupick/category/CategoryOptionMappingGraph.java
@@ -1,0 +1,161 @@
+package subscribenlike.mogupick.category;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.stereotype.Component;
+import subscribenlike.mogupick.category.domain.CategoryOption;
+import subscribenlike.mogupick.category.domain.CategoryOptionFilter;
+import subscribenlike.mogupick.category.domain.RootCategory;
+import subscribenlike.mogupick.category.model.CategoryOptionAndFilterResponse;
+import subscribenlike.mogupick.category.model.CategoryOptionDto;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+public class CategoryOptionMappingGraph {
+
+    private final Map<RootCategory, ArrayList<CategoryOptionMappingNode>> graph;
+
+    private CategoryOptionMappingGraph() {
+        this.graph = new ConcurrentHashMap<>();
+        init();
+    }
+
+    public void init() {
+        graphInit();
+        optionsInit();
+        optionFiltersInit();
+    }
+
+    private void graphInit() {
+        // 루트 카테고리 별 옵션 리스트 생성
+        Arrays.stream(RootCategory.values())
+                .forEach(rootCategory -> graph.put(rootCategory, new ArrayList<>()));
+    }
+
+    private void optionFiltersInit() {
+        // 가격 범위 필터 (범위 + 선택)
+        addFilters(RootCategory.CONVENIENCE_FOOD, CategoryOption.PRICE,
+                CategoryOptionFilter.of("10,000원 미만", "(0,10000)"),
+                CategoryOptionFilter.of("10,000원 이상-20,000원 미만", "[10000,20000)"),
+                CategoryOptionFilter.of("20,000원 이상-30,000원 미만", "[20000,30000)"),
+                CategoryOptionFilter.of("30,000원 이상-40,000원 미만", "[30000,40000)"),
+                CategoryOptionFilter.of("40,000원 이상", "[40000,)")
+        );
+
+        // 별점 갯수 필터 (단일 선택)
+        addFilters(RootCategory.CONVENIENCE_FOOD, CategoryOption.RATING,
+                CategoryOptionFilter.of("1개", "1"),
+                CategoryOptionFilter.of("2개", "2"),
+                CategoryOptionFilter.of("3개", "3"),
+                CategoryOptionFilter.of("4개", "4"),
+                CategoryOptionFilter.of("5개", "5")
+        );
+
+        // 중량 필터 (복수 선택)
+        addFilters(RootCategory.CONVENIENCE_FOOD, CategoryOption.WEIGHT,
+                CategoryOptionFilter.of("200g 이하", "(0,200]"),
+                CategoryOptionFilter.of("200g-500g", "(200,500]"),
+                CategoryOptionFilter.of("500g-1kg", "(500,1000]"),
+                CategoryOptionFilter.of("1kg-2kg", "(1000,2000]"),
+                CategoryOptionFilter.of("2kg-3kg", "(2000,3000]"),
+                CategoryOptionFilter.of("3kg 이상", "(3000,)")
+        );
+
+        // 간편식 섭취 방법 필터 (복수 선택)
+        addFilters(RootCategory.CONVENIENCE_FOOD, CategoryOption.EAT_METHOD,
+                CategoryOptionFilter.of("즉석완조리식품", "즉석완조리식품"),
+                CategoryOptionFilter.of("즉석섭취식품", "즉석섭취식품"),
+                CategoryOptionFilter.of("즉석반조리식품", "즉석반조리식품")
+        );
+
+        // 칼로리 필터 (복수 선택)
+        addFilters(RootCategory.CONVENIENCE_FOOD, CategoryOption.CALORIE,
+                CategoryOptionFilter.of("100kcal 이하", "(0,100]"),
+                CategoryOptionFilter.of("100kcal-200kcal", "(100,200]"),
+                CategoryOptionFilter.of("200kcal-300kcal", "(200,300]"),
+                CategoryOptionFilter.of("300kcal-500kcal", "(300,500]"),
+                CategoryOptionFilter.of("500kcal 이상", "(500,)")
+        );
+
+        // 에어프라이어 전자렌지 조리 가능 필터 (복수 선택)
+        addFilters(RootCategory.CONVENIENCE_FOOD, CategoryOption.COOK_METHOD,
+                CategoryOptionFilter.of("에어프라이어", "에어프라이어"),
+                CategoryOptionFilter.of("에어프라이어,전자렌지", "에어프라이어,전자렌지"),
+                CategoryOptionFilter.of("전자렌지", "전자렌지")
+        );
+
+        // 개당 수량 필터 (복수 선택)
+        addFilters(RootCategory.CONVENIENCE_FOOD, CategoryOption.QUANTITY,
+                CategoryOptionFilter.of("6개 이하", "(0,6]"),
+                CategoryOptionFilter.of("6개-10개", "(6,10]"),
+                CategoryOptionFilter.of("10개-20개", "(10,20]"),
+                CategoryOptionFilter.of("20개-30개", "(20,30]"),
+                CategoryOptionFilter.of("50개 이상", "[50,)")
+        );
+    }
+
+    private void optionsInit() {
+        addAllOptions(
+                RootCategory.CONVENIENCE_FOOD,
+                CategoryOption.PRICE,
+                CategoryOption.RATING,
+                CategoryOption.WEIGHT,
+                CategoryOption.CALORIE,
+                CategoryOption.QUANTITY,
+                CategoryOption.EAT_METHOD,
+                CategoryOption.COOK_METHOD);
+    }
+
+    public List<CategoryOption> getOptionsByRootCategory(RootCategory rootCategory) {
+        return graph.get(rootCategory).stream()
+                .map(CategoryOptionMappingNode::getCategoryOption)
+                .toList();
+    }
+
+    public List<CategoryOptionAndFilterResponse> getOptionAndFiltersByRootCategory(RootCategory rootCategory) {
+        return graph.get(rootCategory).stream()
+                .map(node ->
+                        CategoryOptionAndFilterResponse.of(
+                                CategoryOptionDto.from(node.getCategoryOption()),
+                                node.getFilters()
+                        ))
+                .toList();
+    }
+
+    private void addAllOptions(RootCategory rootCategory, CategoryOption... options) {
+        Arrays.stream(options).forEach(option ->
+                graph.get(rootCategory).add(CategoryOptionMappingNode.of(rootCategory, option))
+        );
+    }
+
+    private void addFilters(RootCategory rootCategory,
+                            CategoryOption categoryOption,
+                            CategoryOptionFilter... filters) {
+
+        CategoryOptionMappingNode node = graph.get(rootCategory).stream()
+                .filter(n -> n.getCategoryOption() == categoryOption)
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "%s 에 %s 옵션이 존재하지 않습니다.".formatted(rootCategory.name(), categoryOption.name())));
+
+        node.addFilter(filters);
+    }
+}
+
+@Getter
+@AllArgsConstructor(staticName = "of")
+class CategoryOptionMappingNode {
+    private RootCategory rootCategory;
+    private CategoryOption categoryOption;
+    private final ArrayList<CategoryOptionFilter> filters = new ArrayList<>();
+
+    public void addFilter(CategoryOptionFilter... optionFilters) {
+        filters.addAll(Arrays.asList(optionFilters));
+    }
+}
+

--- a/src/main/java/subscribenlike/mogupick/category/CategoryService.java
+++ b/src/main/java/subscribenlike/mogupick/category/CategoryService.java
@@ -1,0 +1,28 @@
+package subscribenlike.mogupick.category;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import subscribenlike.mogupick.category.domain.RootCategory;
+import subscribenlike.mogupick.category.model.CategoryOptionAndFilterResponse;
+import subscribenlike.mogupick.category.model.RootCategoryResponse;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CategoryService {
+
+    private final CategoryOptionMappingGraph categoryOptionMappingGraph;
+
+    public List<RootCategoryResponse> getRootCategories() {
+        // 카테고리 리스트 조회
+        return Arrays.stream(RootCategory.values()).map(RootCategoryResponse::from).toList();
+    }
+
+    public List<CategoryOptionAndFilterResponse> getFiltersByRootCategoryAndOption(RootCategory rootCategory) {
+        // 카테고리 옵션 및 옵션에 대한 필터 리스트 조회
+        return categoryOptionMappingGraph.getOptionAndFiltersByRootCategory(rootCategory);
+    }
+}

--- a/src/main/java/subscribenlike/mogupick/category/common/sucess/CategorySuccessCode.java
+++ b/src/main/java/subscribenlike/mogupick/category/common/sucess/CategorySuccessCode.java
@@ -1,0 +1,19 @@
+package subscribenlike.mogupick.category.common.sucess;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import subscribenlike.mogupick.common.success.SuccessCode;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public enum CategorySuccessCode implements SuccessCode {
+    ROOT_CATEGORIES_FETCHED(HttpStatus.OK, "루트 카테고리 리스트 조회에 성공하였습니다."),
+    CATEGORY_OPTIONS_AND_FILTERS_FETCHED(HttpStatus.OK, "카테고리 옵션 및 필터 조회에 성공하였습니다.")
+
+    ;
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/subscribenlike/mogupick/category/common/sucess/CategorySuccessCode.java
+++ b/src/main/java/subscribenlike/mogupick/category/common/sucess/CategorySuccessCode.java
@@ -10,9 +10,7 @@ import subscribenlike.mogupick.common.success.SuccessCode;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public enum CategorySuccessCode implements SuccessCode {
     ROOT_CATEGORIES_FETCHED(HttpStatus.OK, "루트 카테고리 리스트 조회에 성공하였습니다."),
-    CATEGORY_OPTIONS_AND_FILTERS_FETCHED(HttpStatus.OK, "카테고리 옵션 및 필터 조회에 성공하였습니다.")
-
-    ;
+    CATEGORY_OPTIONS_AND_FILTERS_FETCHED(HttpStatus.OK, "카테고리 옵션 및 필터 조회에 성공하였습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/subscribenlike/mogupick/category/domain/CategoryOption.java
+++ b/src/main/java/subscribenlike/mogupick/category/domain/CategoryOption.java
@@ -1,0 +1,22 @@
+package subscribenlike.mogupick.category.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CategoryOption {
+
+    PRICE("가격", CategoryOptionType.RANGE, false),
+    RATING("별점 갯수", CategoryOptionType.CHOICE, false),
+    WEIGHT("중량", CategoryOptionType.CHOICE, true),
+    CALORIE("칼로리", CategoryOptionType.CHOICE, true),
+    QUANTITY("개당 수량", CategoryOptionType.CHOICE, true),
+    EAT_METHOD("간편식 섭취 방법", CategoryOptionType.CHOICE, true),
+    COOK_METHOD("에어프라이어 전자렌지 조리 가능", CategoryOptionType.CHOICE, true),
+    ;
+
+    private final String name;
+    private final CategoryOptionType type;
+    private final boolean isMultiple;
+}

--- a/src/main/java/subscribenlike/mogupick/category/domain/CategoryOptionFilter.java
+++ b/src/main/java/subscribenlike/mogupick/category/domain/CategoryOptionFilter.java
@@ -1,0 +1,11 @@
+package subscribenlike.mogupick.category.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(staticName = "of")
+public class CategoryOptionFilter {
+    private String name;
+    private String expression;
+}

--- a/src/main/java/subscribenlike/mogupick/category/domain/CategoryOptionType.java
+++ b/src/main/java/subscribenlike/mogupick/category/domain/CategoryOptionType.java
@@ -1,0 +1,9 @@
+package subscribenlike.mogupick.category.domain;
+
+public enum CategoryOptionType {
+    RANGE,
+    CHOICE,
+    KEYWORD,
+
+    ;
+}

--- a/src/main/java/subscribenlike/mogupick/category/domain/RootCategory.java
+++ b/src/main/java/subscribenlike/mogupick/category/domain/RootCategory.java
@@ -1,0 +1,22 @@
+package subscribenlike.mogupick.category.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum RootCategory {
+    FRESH_FOOD("신선식품"),
+    MEAT_SEAFOOD("정육·수산물"),
+    DAIRY_BEVERAGE("유제품·음료"),
+    CONVENIENCE_FOOD("간편식"),
+    SNACK("간식"),
+    HEALTH_SUPPLEMENTS("건강식품"),
+    DAILY_GOODS("생활 잡화"),
+    HYGIENE("위생용품"),
+    PET_SUPPLIES("반려동물"),
+    BABY_SUPPLIES("육아용품");
+
+    private final String name;
+}
+

--- a/src/main/java/subscribenlike/mogupick/category/domain/SubCategory.java
+++ b/src/main/java/subscribenlike/mogupick/category/domain/SubCategory.java
@@ -1,0 +1,60 @@
+package subscribenlike.mogupick.category.domain;
+
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SubCategory {
+    FRUIT("과일", RootCategory.FRESH_FOOD),
+    VEGETABLE("채소", RootCategory.FRESH_FOOD),
+    RICE_GRAINS("쌀·잡곡", RootCategory.FRESH_FOOD),
+
+    MEAT("정육", RootCategory.MEAT_SEAFOOD),
+    EGG("계란·난류", RootCategory.MEAT_SEAFOOD),
+    SEAFOOD("수산물", RootCategory.MEAT_SEAFOOD),
+    PROCESSED_MEAT_SEAFOOD("가공육·해산물", RootCategory.MEAT_SEAFOOD),
+
+    DAIRY("유제품", RootCategory.DAIRY_BEVERAGE),
+    BEVERAGE("음료", RootCategory.DAIRY_BEVERAGE),
+
+    FROZEN("냉동식품", RootCategory.CONVENIENCE_FOOD),
+    MEAL_KIT("밀키트", RootCategory.CONVENIENCE_FOOD),
+    LUNCH_SALAD("도시락·샐러드", RootCategory.CONVENIENCE_FOOD),
+
+    SNACKS("과자·스낵", RootCategory.SNACK),
+    BREAD_DESSERT("빵·디저트", RootCategory.SNACK),
+    ICE_CREAM("아이스크림·빙과", RootCategory.SNACK),
+    CHOCOLATE_CANDY("초콜릿·캔디·껌", RootCategory.SNACK),
+
+    VITAMINS("비타민·미네랄", RootCategory.HEALTH_SUPPLEMENTS),
+    OMEGA_PROBIOTICS("오메가·유산균·홍삼", RootCategory.HEALTH_SUPPLEMENTS),
+    PROTEIN_SUPPLEMENTS("단백질·헬스 보조제", RootCategory.HEALTH_SUPPLEMENTS),
+    HEALTH_TEA_POWDER("건강차·분말류", RootCategory.HEALTH_SUPPLEMENTS),
+
+    KITCHEN("주방용품", RootCategory.DAILY_GOODS),
+    CLEANING("청소용품", RootCategory.DAILY_GOODS),
+    LAUNDRY("세탁용품", RootCategory.DAILY_GOODS),
+    STATIONERY_APPLIANCES("문구·소형가전", RootCategory.DAILY_GOODS),
+
+    PERSONAL_HYGIENE("개인 위생", RootCategory.HYGIENE),
+    HYGIENE_CONSUMABLES("위생 소모품", RootCategory.HYGIENE),
+    ORAL_SKINCARE("구강·스킨케어 기본품", RootCategory.HYGIENE),
+
+    DOG_FOOD("강아지 식품", RootCategory.PET_SUPPLIES),
+    CAT_FOOD("고양이 식품", RootCategory.PET_SUPPLIES),
+    PET_HYGIENE("위생·관리", RootCategory.PET_SUPPLIES),
+    PET_TOY_HOUSE("장난감·하우스", RootCategory.PET_SUPPLIES),
+
+    DIAPER_WIPES("기저귀·물티슈", RootCategory.BABY_SUPPLIES),
+    FORMULA_BABYFOOD("분유·이유식", RootCategory.BABY_SUPPLIES),
+    WEANING_SUPPLIES("이유용품", RootCategory.BABY_SUPPLIES),
+    BABY_BATH("유아 위생·목욕용품", RootCategory.BABY_SUPPLIES),
+    BABY_SNACK_BEVERAGE("유아 간식·음료", RootCategory.BABY_SUPPLIES);
+
+    private final String name;
+    private final RootCategory root;
+
+}
+

--- a/src/main/java/subscribenlike/mogupick/category/model/CategoryOptionAndFilterResponse.java
+++ b/src/main/java/subscribenlike/mogupick/category/model/CategoryOptionAndFilterResponse.java
@@ -1,0 +1,16 @@
+package subscribenlike.mogupick.category.model;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import subscribenlike.mogupick.category.domain.CategoryOptionFilter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor(staticName = "of")
+public class CategoryOptionAndFilterResponse {
+    private CategoryOptionDto option;
+    private List<CategoryOptionFilter> optionFilters;
+}
+

--- a/src/main/java/subscribenlike/mogupick/category/model/CategoryOptionDto.java
+++ b/src/main/java/subscribenlike/mogupick/category/model/CategoryOptionDto.java
@@ -1,5 +1,6 @@
 package subscribenlike.mogupick.category.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -10,6 +11,8 @@ import subscribenlike.mogupick.category.domain.CategoryOption;
 public class CategoryOptionDto {
     private String name;
     private String type;
+    
+    @JsonProperty("multiple")
     private boolean isMultiple;
 
     public static CategoryOptionDto from(CategoryOption option) {

--- a/src/main/java/subscribenlike/mogupick/category/model/CategoryOptionDto.java
+++ b/src/main/java/subscribenlike/mogupick/category/model/CategoryOptionDto.java
@@ -1,0 +1,18 @@
+package subscribenlike.mogupick.category.model;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import subscribenlike.mogupick.category.domain.CategoryOption;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class CategoryOptionDto {
+    private String name;
+    private String type;
+    private boolean isMultiple;
+
+    public static CategoryOptionDto from(CategoryOption option) {
+        return new CategoryOptionDto(option.getName(), option.getType().name(), option.isMultiple());
+    }
+}

--- a/src/main/java/subscribenlike/mogupick/category/model/RootCategoryResponse.java
+++ b/src/main/java/subscribenlike/mogupick/category/model/RootCategoryResponse.java
@@ -1,0 +1,17 @@
+package subscribenlike.mogupick.category.model;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import subscribenlike.mogupick.category.domain.RootCategory;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class RootCategoryResponse {
+    private RootCategory rootCategory;
+    private String name;
+
+    public static RootCategoryResponse from(RootCategory rootCategory) {
+        return new RootCategoryResponse(rootCategory, rootCategory.getName());
+    }
+}

--- a/src/test/java/subscribenlike/mogupick/category/CategoryControllerTest.java
+++ b/src/test/java/subscribenlike/mogupick/category/CategoryControllerTest.java
@@ -1,0 +1,255 @@
+package subscribenlike.mogupick.category;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.ActiveProfiles;
+import subscribenlike.mogupick.category.domain.RootCategory;
+import subscribenlike.mogupick.category.model.CategoryOptionAndFilterResponse;
+import subscribenlike.mogupick.category.model.RootCategoryResponse;
+import subscribenlike.mogupick.support.DatabaseCleanerExtension;
+import subscribenlike.mogupick.support.fixture.CategoryFixture;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@org.junit.jupiter.api.extension.ExtendWith(DatabaseCleanerExtension.class)
+class CategoryControllerTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private CategoryController categoryController;
+
+    @Test
+    void 루트_카테고리_리스트_조회_API가_정상적으로_동작한다() {
+        // When
+        ExtractableResponse<Response> response = RestAssured
+                .given().log().all()
+                .when()
+                .get("http://localhost:" + port + "/api/v1/categories/root")
+                .then().log().all()
+                .extract();
+
+        // Then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        
+        var responseBody = response.jsonPath();
+        assertThat(responseBody.getInt("status")).isEqualTo(HttpStatus.OK.value());
+        assertThat(responseBody.getString("message")).isEqualTo("루트 카테고리 리스트 조회에 성공하였습니다.");
+        
+        List<RootCategoryResponse> data = responseBody.getList("data", RootCategoryResponse.class);
+        assertThat(data).hasSize(10);
+    }
+
+    @Test
+    void 루트_카테고리_리스트_조회_API_응답에_올바른_카테고리들이_포함되어_있다() {
+        // When
+        ExtractableResponse<Response> response = RestAssured
+                .given().log().all()
+                .when()
+                .get("http://localhost:" + port + "/api/v1/categories/root")
+                .then().log().all()
+                .extract();
+
+        // Then
+        var responseBody = response.jsonPath();
+        List<RootCategoryResponse> data = responseBody.getList("data", RootCategoryResponse.class);
+        
+        assertThat(data)
+                .extracting("name")
+                .containsExactlyInAnyOrder(
+                        "신선식품",
+                        "정육·수산물",
+                        "유제품·음료",
+                        "간편식",
+                        "간식",
+                        "건강식품",
+                        "생활 잡화",
+                        "위생용품",
+                        "반려동물",
+                        "육아용품"
+                );
+    }
+
+    @Test
+    void 카테고리_옵션과_필터_조회_API가_정상적으로_동작한다() {
+        // Given
+        RootCategory convenienceFood = CategoryFixture.간편식();
+
+        // When
+        ExtractableResponse<Response> response = RestAssured
+                .given().log().all()
+                .queryParam("rootCategory", convenienceFood.name())
+                .when()
+                .get("http://localhost:" + port + "/api/v1/categories/options-filters")
+                .then().log().all()
+                .extract();
+
+        // Then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        
+        var responseBody = response.jsonPath();
+        assertThat(responseBody.getInt("status")).isEqualTo(HttpStatus.OK.value());
+        assertThat(responseBody.getString("message")).isEqualTo("카테고리 옵션 및 필터 조회에 성공하였습니다.");
+        
+        List<CategoryOptionAndFilterResponse> data = responseBody.getList("data", CategoryOptionAndFilterResponse.class);
+        assertThat(data).hasSize(7);
+    }
+
+    @Test
+    void 간편식_카테고리의_옵션과_필터_조회_API_응답에_올바른_옵션들이_포함되어_있다() {
+        // Given
+        RootCategory convenienceFood = CategoryFixture.간편식();
+
+        // When
+        ExtractableResponse<Response> response = RestAssured
+                .given().log().all()
+                .queryParam("rootCategory", convenienceFood.name())
+                .when()
+                .get("http://localhost:" + port + "/api/v1/categories/options-filters")
+                .then().log().all()
+                .extract();
+
+        // Then
+        var responseBody = response.jsonPath();
+        List<CategoryOptionAndFilterResponse> data = responseBody.getList("data", CategoryOptionAndFilterResponse.class);
+        
+        assertThat(data)
+                .extracting("option.name")
+                .containsExactlyInAnyOrder(
+                        "가격",
+                        "별점 갯수",
+                        "중량",
+                        "칼로리",
+                        "개당 수량",
+                        "간편식 섭취 방법",
+                        "에어프라이어 전자렌지 조리 가능"
+                );
+    }
+
+    @Test
+    void 간편식_카테고리의_가격_옵션_필터가_올바르게_설정되어_있다() {
+        // Given
+        RootCategory convenienceFood = CategoryFixture.간편식();
+
+        // When
+        ExtractableResponse<Response> response = RestAssured
+                .given().log().all()
+                .queryParam("rootCategory", convenienceFood.name())
+                .when()
+                .get("http://localhost:" + port + "/api/v1/categories/options-filters")
+                .then().log().all()
+                .extract();
+
+        // Then
+        var responseBody = response.jsonPath();
+        List<CategoryOptionAndFilterResponse> data = responseBody.getList("data", CategoryOptionAndFilterResponse.class);
+        
+        // 가격 옵션 찾기
+        var priceOption = data.stream()
+                .filter(option -> option.getOption().getName().equals("가격"))
+                .findFirst()
+                .orElseThrow();
+        
+        assertThat(priceOption.getOption().getType()).isEqualTo("RANGE");
+        assertThat(priceOption.getOption().isMultiple()).isFalse();
+        assertThat(priceOption.getOptionFilters()).hasSize(5);
+    }
+
+    @Test
+    void 간편식_카테고리의_별점_옵션_필터가_올바르게_설정되어_있다() {
+        // Given
+        RootCategory convenienceFood = CategoryFixture.간편식();
+
+        // When
+        ExtractableResponse<Response> response = RestAssured
+                .given().log().all()
+                .queryParam("rootCategory", convenienceFood.name())
+                .when()
+                .get("http://localhost:" + port + "/api/v1/categories/options-filters")
+                .then().log().all()
+                .extract();
+
+        // Then
+        var responseBody = response.jsonPath();
+        List<CategoryOptionAndFilterResponse> data = responseBody.getList("data", CategoryOptionAndFilterResponse.class);
+        
+        // 별점 옵션 찾기
+        var ratingOption = data.stream()
+                .filter(option -> option.getOption().getName().equals("별점 갯수"))
+                .findFirst()
+                .orElseThrow();
+        
+        assertThat(ratingOption.getOption().getType()).isEqualTo("CHOICE");
+        assertThat(ratingOption.getOption().isMultiple()).isFalse();
+        assertThat(ratingOption.getOptionFilters()).hasSize(5);
+    }
+
+    @Test
+    void 간편식_카테고리의_중량_옵션_필터가_올바르게_설정되어_있다() {
+        // Given
+        RootCategory convenienceFood = CategoryFixture.간편식();
+
+        // When
+        ExtractableResponse<Response> response = RestAssured
+                .given().log().all()
+                .queryParam("rootCategory", convenienceFood.name())
+                .when()
+                .get("http://localhost:" + port + "/api/v1/categories/options-filters")
+                .then().log().all()
+                .extract();
+
+        // Then
+        var responseBody = response.jsonPath();
+        List<CategoryOptionAndFilterResponse> data = responseBody.getList("data", CategoryOptionAndFilterResponse.class);
+        
+        // 중량 옵션 찾기
+        var weightOption = data.stream()
+                .filter(option -> option.getOption().getName().equals("중량"))
+                .findFirst()
+                .orElseThrow();
+        
+        assertThat(weightOption.getOption().getType()).isEqualTo("CHOICE");
+        assertThat(weightOption.getOption().isMultiple()).isTrue();
+        assertThat(weightOption.getOptionFilters()).hasSize(6);
+    }
+
+    @Test
+    void 잘못된_루트카테고리_파라미터로_요청시_500_에러가_발생한다() {
+        // When
+        ExtractableResponse<Response> response = RestAssured
+                .given().log().all()
+                .queryParam("rootCategory", "INVALID_CATEGORY")
+                .when()
+                .get("http://localhost:" + port + "/api/v1/categories/options-filters")
+                .then().log().all()
+                .extract();
+
+        // Then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.value());
+    }
+
+    @Test
+    void 루트카테고리_파라미터가_없을_경우_500_에러가_발생한다() {
+        // When
+        ExtractableResponse<Response> response = RestAssured
+                .given().log().all()
+                .when()
+                .get("http://localhost:" + port + "/api/v1/categories/options-filters")
+                .then().log().all()
+                .extract();
+
+        // Then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.value());
+    }
+}

--- a/src/test/java/subscribenlike/mogupick/category/CategoryOptionMappingGraphTest.java
+++ b/src/test/java/subscribenlike/mogupick/category/CategoryOptionMappingGraphTest.java
@@ -1,0 +1,233 @@
+package subscribenlike.mogupick.category;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import subscribenlike.mogupick.category.domain.CategoryOption;
+import subscribenlike.mogupick.category.domain.RootCategory;
+import subscribenlike.mogupick.category.model.CategoryOptionAndFilterResponse;
+import subscribenlike.mogupick.support.annotation.ServiceTest;
+import subscribenlike.mogupick.support.fixture.CategoryFixture;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ServiceTest
+class CategoryOptionMappingGraphTest {
+
+    @Autowired
+    private CategoryOptionMappingGraph categoryOptionMappingGraph;
+
+    @Test
+    void 간편식_카테고리의_옵션_리스트를_조회할_수_있다() {
+        // Given
+        RootCategory convenienceFood = CategoryFixture.간편식();
+
+        // When
+        List<CategoryOption> options = categoryOptionMappingGraph.getOptionsByRootCategory(convenienceFood);
+
+        // Then
+        assertThat(options).hasSize(7);
+        assertThat(options).containsExactlyInAnyOrder(
+                CategoryOption.PRICE,
+                CategoryOption.RATING,
+                CategoryOption.WEIGHT,
+                CategoryOption.CALORIE,
+                CategoryOption.QUANTITY,
+                CategoryOption.EAT_METHOD,
+                CategoryOption.COOK_METHOD
+        );
+    }
+
+    @Test
+    void 간편식_카테고리의_옵션과_필터_리스트를_조회할_수_있다() {
+        // Given
+        RootCategory convenienceFood = CategoryFixture.간편식();
+
+        // When
+        List<CategoryOptionAndFilterResponse> optionsAndFilters = 
+                categoryOptionMappingGraph.getOptionAndFiltersByRootCategory(convenienceFood);
+
+        // Then
+        assertThat(optionsAndFilters).hasSize(7);
+        
+        // 각 옵션의 이름 확인
+        assertThat(optionsAndFilters)
+                .extracting("option.name")
+                .containsExactlyInAnyOrder(
+                        "가격",
+                        "별점 갯수",
+                        "중량",
+                        "칼로리",
+                        "개당 수량",
+                        "간편식 섭취 방법",
+                        "에어프라이어 전자렌지 조리 가능"
+                );
+    }
+
+    @Test
+    void 간편식_카테고리의_가격_옵션이_올바르게_설정되어_있다() {
+        // Given
+        RootCategory convenienceFood = CategoryFixture.간편식();
+
+        // When
+        List<CategoryOptionAndFilterResponse> optionsAndFilters = 
+                categoryOptionMappingGraph.getOptionAndFiltersByRootCategory(convenienceFood);
+
+        // Then
+        CategoryOptionAndFilterResponse priceOption = optionsAndFilters.stream()
+                .filter(response -> response.getOption().getName().equals("가격"))
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(priceOption.getOption().getType()).isEqualTo("RANGE");
+        assertThat(priceOption.getOption().isMultiple()).isFalse();
+        assertThat(priceOption.getOptionFilters()).hasSize(5);
+    }
+
+    @Test
+    void 간편식_카테고리의_별점_옵션이_올바르게_설정되어_있다() {
+        // Given
+        RootCategory convenienceFood = CategoryFixture.간편식();
+
+        // When
+        List<CategoryOptionAndFilterResponse> optionsAndFilters = 
+                categoryOptionMappingGraph.getOptionAndFiltersByRootCategory(convenienceFood);
+
+        // Then
+        CategoryOptionAndFilterResponse ratingOption = optionsAndFilters.stream()
+                .filter(response -> response.getOption().getName().equals("별점 갯수"))
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(ratingOption.getOption().getType()).isEqualTo("CHOICE");
+        assertThat(ratingOption.getOption().isMultiple()).isFalse();
+        assertThat(ratingOption.getOptionFilters()).hasSize(5);
+    }
+
+    @Test
+    void 간편식_카테고리의_중량_옵션이_올바르게_설정되어_있다() {
+        // Given
+        RootCategory convenienceFood = CategoryFixture.간편식();
+
+        // When
+        List<CategoryOptionAndFilterResponse> optionsAndFilters = 
+                categoryOptionMappingGraph.getOptionAndFiltersByRootCategory(convenienceFood);
+
+        // Then
+        CategoryOptionAndFilterResponse weightOption = optionsAndFilters.stream()
+                .filter(response -> response.getOption().getName().equals("중량"))
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(weightOption.getOption().getType()).isEqualTo("CHOICE");
+        assertThat(weightOption.getOption().isMultiple()).isTrue();
+        assertThat(weightOption.getOptionFilters()).hasSize(6);
+    }
+
+    @Test
+    void 간편식_카테고리의_칼로리_옵션이_올바르게_설정되어_있다() {
+        // Given
+        RootCategory convenienceFood = CategoryFixture.간편식();
+
+        // When
+        List<CategoryOptionAndFilterResponse> optionsAndFilters = 
+                categoryOptionMappingGraph.getOptionAndFiltersByRootCategory(convenienceFood);
+
+        // Then
+        CategoryOptionAndFilterResponse calorieOption = optionsAndFilters.stream()
+                .filter(response -> response.getOption().getName().equals("칼로리"))
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(calorieOption.getOption().getType()).isEqualTo("CHOICE");
+        assertThat(calorieOption.getOption().isMultiple()).isTrue();
+        assertThat(calorieOption.getOptionFilters()).hasSize(5);
+    }
+
+    @Test
+    void 간편식_카테고리의_개당수량_옵션이_올바르게_설정되어_있다() {
+        // Given
+        RootCategory convenienceFood = CategoryFixture.간편식();
+
+        // When
+        List<CategoryOptionAndFilterResponse> optionsAndFilters = 
+                categoryOptionMappingGraph.getOptionAndFiltersByRootCategory(convenienceFood);
+
+        // Then
+        CategoryOptionAndFilterResponse quantityOption = optionsAndFilters.stream()
+                .filter(response -> response.getOption().getName().equals("개당 수량"))
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(quantityOption.getOption().getType()).isEqualTo("CHOICE");
+        assertThat(quantityOption.getOption().isMultiple()).isTrue();
+        assertThat(quantityOption.getOptionFilters()).hasSize(5);
+    }
+
+    @Test
+    void 간편식_카테고리의_섭취방법_옵션이_올바르게_설정되어_있다() {
+        // Given
+        RootCategory convenienceFood = CategoryFixture.간편식();
+
+        // When
+        List<CategoryOptionAndFilterResponse> optionsAndFilters = 
+                categoryOptionMappingGraph.getOptionAndFiltersByRootCategory(convenienceFood);
+
+        // Then
+        CategoryOptionAndFilterResponse eatMethodOption = optionsAndFilters.stream()
+                .filter(response -> response.getOption().getName().equals("간편식 섭취 방법"))
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(eatMethodOption.getOption().getType()).isEqualTo("CHOICE");
+        assertThat(eatMethodOption.getOption().isMultiple()).isTrue();
+        assertThat(eatMethodOption.getOptionFilters()).hasSize(3);
+    }
+
+    @Test
+    void 간편식_카테고리의_조리방법_옵션이_올바르게_설정되어_있다() {
+        // Given
+        RootCategory convenienceFood = CategoryFixture.간편식();
+
+        // When
+        List<CategoryOptionAndFilterResponse> optionsAndFilters = 
+                categoryOptionMappingGraph.getOptionAndFiltersByRootCategory(convenienceFood);
+
+        // Then
+        CategoryOptionAndFilterResponse cookMethodOption = optionsAndFilters.stream()
+                .filter(response -> response.getOption().getName().equals("에어프라이어 전자렌지 조리 가능"))
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(cookMethodOption.getOption().getType()).isEqualTo("CHOICE");
+        assertThat(cookMethodOption.getOption().isMultiple()).isTrue();
+        assertThat(cookMethodOption.getOptionFilters()).hasSize(3);
+    }
+
+    @Test
+    void 다른_카테고리들은_옵션이_설정되어_있지_않다() {
+        // Given
+        RootCategory freshFood = CategoryFixture.신선식품();
+        RootCategory meatSeafood = CategoryFixture.정육수산물();
+        RootCategory dairyBeverage = CategoryFixture.유제품음료();
+
+        // When & Then
+        assertThat(categoryOptionMappingGraph.getOptionsByRootCategory(freshFood)).isEmpty();
+        assertThat(categoryOptionMappingGraph.getOptionsByRootCategory(meatSeafood)).isEmpty();
+        assertThat(categoryOptionMappingGraph.getOptionsByRootCategory(dairyBeverage)).isEmpty();
+    }
+
+    @Test
+    void 다른_카테고리들은_옵션과_필터가_설정되어_있지_않다() {
+        // Given
+        RootCategory freshFood = CategoryFixture.신선식품();
+        RootCategory meatSeafood = CategoryFixture.정육수산물();
+        RootCategory dairyBeverage = CategoryFixture.유제품음료();
+
+        // When & Then
+        assertThat(categoryOptionMappingGraph.getOptionAndFiltersByRootCategory(freshFood)).isEmpty();
+        assertThat(categoryOptionMappingGraph.getOptionAndFiltersByRootCategory(meatSeafood)).isEmpty();
+        assertThat(categoryOptionMappingGraph.getOptionAndFiltersByRootCategory(dairyBeverage)).isEmpty();
+    }
+}

--- a/src/test/java/subscribenlike/mogupick/category/CategoryServiceTest.java
+++ b/src/test/java/subscribenlike/mogupick/category/CategoryServiceTest.java
@@ -1,0 +1,282 @@
+package subscribenlike.mogupick.category;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import subscribenlike.mogupick.category.domain.RootCategory;
+import subscribenlike.mogupick.category.model.CategoryOptionAndFilterResponse;
+import subscribenlike.mogupick.category.model.RootCategoryResponse;
+import subscribenlike.mogupick.support.annotation.ServiceTest;
+import subscribenlike.mogupick.support.fixture.CategoryFixture;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ServiceTest
+class CategoryServiceTest {
+
+    @Autowired
+    private CategoryService categoryService;
+
+    @Test
+    void 루트_카테고리_리스트를_조회할_수_있다() {
+        // When
+        List<RootCategoryResponse> rootCategories = categoryService.getRootCategories();
+
+        // Then
+        assertThat(rootCategories).hasSize(10);
+        assertThat(rootCategories)
+                .extracting("rootCategory")
+                .containsExactlyInAnyOrder(
+                        RootCategory.FRESH_FOOD,
+                        RootCategory.MEAT_SEAFOOD,
+                        RootCategory.DAIRY_BEVERAGE,
+                        RootCategory.CONVENIENCE_FOOD,
+                        RootCategory.SNACK,
+                        RootCategory.HEALTH_SUPPLEMENTS,
+                        RootCategory.DAILY_GOODS,
+                        RootCategory.HYGIENE,
+                        RootCategory.PET_SUPPLIES,
+                        RootCategory.BABY_SUPPLIES
+                );
+    }
+
+    @Test
+    void 루트_카테고리_응답에_올바른_이름이_포함되어_있다() {
+        // When
+        List<RootCategoryResponse> rootCategories = categoryService.getRootCategories();
+
+        // Then
+        assertThat(rootCategories)
+                .extracting("name")
+                .containsExactlyInAnyOrder(
+                        "신선식품",
+                        "정육·수산물",
+                        "유제품·음료",
+                        "간편식",
+                        "간식",
+                        "건강식품",
+                        "생활 잡화",
+                        "위생용품",
+                        "반려동물",
+                        "육아용품"
+                );
+    }
+
+    @Test
+    void 간편식_카테고리의_옵션과_필터를_조회할_수_있다() {
+        // Given
+        RootCategory convenienceFood = CategoryFixture.간편식();
+
+        // When
+        List<CategoryOptionAndFilterResponse> optionsAndFilters = 
+                categoryService.getFiltersByRootCategoryAndOption(convenienceFood);
+
+        // Then
+        assertThat(optionsAndFilters).hasSize(7);
+        
+        // 가격 옵션 검증
+        assertThat(optionsAndFilters)
+                .anyMatch(response -> 
+                        response.getOption().getName().equals("가격") &&
+                        response.getOption().getType().equals("RANGE") &&
+                        !response.getOption().isMultiple()
+                );
+
+        // 별점 옵션 검증
+        assertThat(optionsAndFilters)
+                .anyMatch(response -> 
+                        response.getOption().getName().equals("별점 갯수") &&
+                        response.getOption().getType().equals("CHOICE") &&
+                        !response.getOption().isMultiple()
+                );
+
+        // 중량 옵션 검증 (복수 선택 가능)
+        assertThat(optionsAndFilters)
+                .anyMatch(response -> 
+                        response.getOption().getName().equals("중량") &&
+                        response.getOption().getType().equals("CHOICE") &&
+                        response.getOption().isMultiple()
+                );
+    }
+
+    @Test
+    void 간편식_카테고리의_가격_필터가_올바르게_설정되어_있다() {
+        // Given
+        RootCategory convenienceFood = CategoryFixture.간편식();
+
+        // When
+        List<CategoryOptionAndFilterResponse> optionsAndFilters = 
+                categoryService.getFiltersByRootCategoryAndOption(convenienceFood);
+
+        // Then
+        CategoryOptionAndFilterResponse priceOption = optionsAndFilters.stream()
+                .filter(response -> response.getOption().getName().equals("가격"))
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(priceOption.getOptionFilters()).hasSize(5);
+        assertThat(priceOption.getOptionFilters())
+                .extracting("name")
+                .containsExactlyInAnyOrder(
+                        "10,000원 미만",
+                        "10,000원 이상-20,000원 미만",
+                        "20,000원 이상-30,000원 미만",
+                        "30,000원 이상-40,000원 미만",
+                        "40,000원 이상"
+                );
+    }
+
+    @Test
+    void 간편식_카테고리의_별점_필터가_올바르게_설정되어_있다() {
+        // Given
+        RootCategory convenienceFood = CategoryFixture.간편식();
+
+        // When
+        List<CategoryOptionAndFilterResponse> optionsAndFilters = 
+                categoryService.getFiltersByRootCategoryAndOption(convenienceFood);
+
+        // Then
+        CategoryOptionAndFilterResponse ratingOption = optionsAndFilters.stream()
+                .filter(response -> response.getOption().getName().equals("별점 갯수"))
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(ratingOption.getOptionFilters()).hasSize(5);
+        assertThat(ratingOption.getOptionFilters())
+                .extracting("name")
+                .containsExactlyInAnyOrder("1개", "2개", "3개", "4개", "5개");
+    }
+
+    @Test
+    void 간편식_카테고리의_중량_필터가_올바르게_설정되어_있다() {
+        // Given
+        RootCategory convenienceFood = CategoryFixture.간편식();
+
+        // When
+        List<CategoryOptionAndFilterResponse> optionsAndFilters = 
+                categoryService.getFiltersByRootCategoryAndOption(convenienceFood);
+
+        // Then
+        CategoryOptionAndFilterResponse weightOption = optionsAndFilters.stream()
+                .filter(response -> response.getOption().getName().equals("중량"))
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(weightOption.getOptionFilters()).hasSize(6);
+        assertThat(weightOption.getOptionFilters())
+                .extracting("name")
+                .containsExactlyInAnyOrder(
+                        "200g 이하",
+                        "200g-500g",
+                        "500g-1kg",
+                        "1kg-2kg",
+                        "2kg-3kg",
+                        "3kg 이상"
+                );
+    }
+
+    @Test
+    void 간편식_카테고리의_칼로리_필터가_올바르게_설정되어_있다() {
+        // Given
+        RootCategory convenienceFood = CategoryFixture.간편식();
+
+        // When
+        List<CategoryOptionAndFilterResponse> optionsAndFilters = 
+                categoryService.getFiltersByRootCategoryAndOption(convenienceFood);
+
+        // Then
+        CategoryOptionAndFilterResponse calorieOption = optionsAndFilters.stream()
+                .filter(response -> response.getOption().getName().equals("칼로리"))
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(calorieOption.getOptionFilters()).hasSize(5);
+        assertThat(calorieOption.getOptionFilters())
+                .extracting("name")
+                .containsExactlyInAnyOrder(
+                        "100kcal 이하",
+                        "100kcal-200kcal",
+                        "200kcal-300kcal",
+                        "300kcal-500kcal",
+                        "500kcal 이상"
+                );
+    }
+
+    @Test
+    void 간편식_카테고리의_개당수량_필터가_올바르게_설정되어_있다() {
+        // Given
+        RootCategory convenienceFood = CategoryFixture.간편식();
+
+        // When
+        List<CategoryOptionAndFilterResponse> optionsAndFilters = 
+                categoryService.getFiltersByRootCategoryAndOption(convenienceFood);
+
+        // Then
+        CategoryOptionAndFilterResponse quantityOption = optionsAndFilters.stream()
+                .filter(response -> response.getOption().getName().equals("개당 수량"))
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(quantityOption.getOptionFilters()).hasSize(5);
+        assertThat(quantityOption.getOptionFilters())
+                .extracting("name")
+                .containsExactlyInAnyOrder(
+                        "6개 이하",
+                        "6개-10개",
+                        "10개-20개",
+                        "20개-30개",
+                        "50개 이상"
+                );
+    }
+
+    @Test
+    void 간편식_카테고리의_섭취방법_필터가_올바르게_설정되어_있다() {
+        // Given
+        RootCategory convenienceFood = CategoryFixture.간편식();
+
+        // When
+        List<CategoryOptionAndFilterResponse> optionsAndFilters = 
+                categoryService.getFiltersByRootCategoryAndOption(convenienceFood);
+
+        // Then
+        CategoryOptionAndFilterResponse eatMethodOption = optionsAndFilters.stream()
+                .filter(response -> response.getOption().getName().equals("간편식 섭취 방법"))
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(eatMethodOption.getOptionFilters()).hasSize(3);
+        assertThat(eatMethodOption.getOptionFilters())
+                .extracting("name")
+                .containsExactlyInAnyOrder(
+                        "즉석완조리식품",
+                        "즉석섭취식품",
+                        "즉석반조리식품"
+                );
+    }
+
+    @Test
+    void 간편식_카테고리의_조리방법_필터가_올바르게_설정되어_있다() {
+        // Given
+        RootCategory convenienceFood = CategoryFixture.간편식();
+
+        // When
+        List<CategoryOptionAndFilterResponse> optionsAndFilters = 
+                categoryService.getFiltersByRootCategoryAndOption(convenienceFood);
+
+        // Then
+        CategoryOptionAndFilterResponse cookMethodOption = optionsAndFilters.stream()
+                .filter(response -> response.getOption().getName().equals("에어프라이어 전자렌지 조리 가능"))
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(cookMethodOption.getOptionFilters()).hasSize(3);
+        assertThat(cookMethodOption.getOptionFilters())
+                .extracting("name")
+                .containsExactlyInAnyOrder(
+                        "에어프라이어",
+                        "에어프라이어,전자렌지",
+                        "전자렌지"
+                );
+    }
+}

--- a/src/test/java/subscribenlike/mogupick/support/fixture/CategoryFixture.java
+++ b/src/test/java/subscribenlike/mogupick/support/fixture/CategoryFixture.java
@@ -1,0 +1,131 @@
+package subscribenlike.mogupick.support.fixture;
+
+import lombok.Getter;
+import subscribenlike.mogupick.category.domain.CategoryOption;
+import subscribenlike.mogupick.category.domain.CategoryOptionFilter;
+import subscribenlike.mogupick.category.domain.CategoryOptionType;
+import subscribenlike.mogupick.category.domain.RootCategory;
+import subscribenlike.mogupick.category.domain.SubCategory;
+
+@Getter
+public enum CategoryFixture {
+    // RootCategory Fixtures
+    신선식품(RootCategory.FRESH_FOOD),
+    정육수산물(RootCategory.MEAT_SEAFOOD),
+    유제품음료(RootCategory.DAIRY_BEVERAGE),
+    간편식(RootCategory.CONVENIENCE_FOOD),
+    간식(RootCategory.SNACK),
+    건강식품(RootCategory.HEALTH_SUPPLEMENTS),
+    생활잡화(RootCategory.DAILY_GOODS),
+    위생용품(RootCategory.HYGIENE),
+    반려동물(RootCategory.PET_SUPPLIES),
+    육아용품(RootCategory.BABY_SUPPLIES);
+
+    private final RootCategory rootCategory;
+
+    CategoryFixture(RootCategory rootCategory) {
+        this.rootCategory = rootCategory;
+    }
+
+    public static RootCategory 신선식품() {
+        return 신선식품.rootCategory;
+    }
+
+    public static RootCategory 정육수산물() {
+        return 정육수산물.rootCategory;
+    }
+
+    public static RootCategory 유제품음료() {
+        return 유제품음료.rootCategory;
+    }
+
+    public static RootCategory 간편식() {
+        return 간편식.rootCategory;
+    }
+
+    public static RootCategory 간식() {
+        return 간식.rootCategory;
+    }
+
+    public static RootCategory 건강식품() {
+        return 건강식품.rootCategory;
+    }
+
+    public static RootCategory 생활잡화() {
+        return 생활잡화.rootCategory;
+    }
+
+    public static RootCategory 위생용품() {
+        return 위생용품.rootCategory;
+    }
+
+    public static RootCategory 반려동물() {
+        return 반려동물.rootCategory;
+    }
+
+    public static RootCategory 육아용품() {
+        return 육아용품.rootCategory;
+    }
+
+    // CategoryOption Fixtures
+    public static CategoryOption 가격옵션() {
+        return CategoryOption.PRICE;
+    }
+
+    public static CategoryOption 별점옵션() {
+        return CategoryOption.RATING;
+    }
+
+    public static CategoryOption 중량옵션() {
+        return CategoryOption.WEIGHT;
+    }
+
+    public static CategoryOption 칼로리옵션() {
+        return CategoryOption.CALORIE;
+    }
+
+    public static CategoryOption 수량옵션() {
+        return CategoryOption.QUANTITY;
+    }
+
+    public static CategoryOption 섭취방법옵션() {
+        return CategoryOption.EAT_METHOD;
+    }
+
+    public static CategoryOption 조리방법옵션() {
+        return CategoryOption.COOK_METHOD;
+    }
+
+    // CategoryOptionFilter Fixtures
+    public static CategoryOptionFilter 가격_1만원미만() {
+        return CategoryOptionFilter.of("10,000원 미만", "(0,10000)");
+    }
+
+    public static CategoryOptionFilter 가격_1만원이상2만원미만() {
+        return CategoryOptionFilter.of("10,000원 이상-20,000원 미만", "[10000,20000)");
+    }
+
+    public static CategoryOptionFilter 별점_5개() {
+        return CategoryOptionFilter.of("5개", "5");
+    }
+
+    public static CategoryOptionFilter 중량_200g이하() {
+        return CategoryOptionFilter.of("200g 이하", "(0,200]");
+    }
+
+    public static CategoryOptionFilter 칼로리_100kcal이하() {
+        return CategoryOptionFilter.of("100kcal 이하", "(0,100]");
+    }
+
+    public static CategoryOptionFilter 수량_6개이하() {
+        return CategoryOptionFilter.of("6개 이하", "(0,6]");
+    }
+
+    public static CategoryOptionFilter 섭취방법_즉석완조리() {
+        return CategoryOptionFilter.of("즉석완조리식품", "즉석완조리식품");
+    }
+
+    public static CategoryOptionFilter 조리방법_에어프라이어() {
+        return CategoryOptionFilter.of("에어프라이어", "에어프라이어");
+    }
+}


### PR DESCRIPTION
# 🚀 What’s this PR about?
- **작업 내용 요약:** 카테고리 및 필터 구조 및 조회 구현

# 🛠️ What’s been done?
- 주요 변경사항을 상세히 기술하세요. (예: 새로운 기능 추가, 버그 수정, 코드 리팩토링 등)
  - 카테고리 구조 정의
     ```
      RootCategory
          ↓ (1:N)
      SubCategory
          ↓ (예: CONVENIENCE_FOOD → FROZEN, MEAL_KIT, LUNCH_SALAD)
      
      RootCategory
          ↓ (1:N)
      CategoryOption
          ↓ (1:N)
      CategoryOptionFilter (각 옵션별 세부 필터)
      ```
  - 메인 카테고리-옵션-필터 매핑 그래프
    ```
    // 루트 카테고리-옵션 쌍에 대한 필터 리스트 정의 (ex. [루트1-옵션1], [루트2-옵션1]은 같은 옵션에 대한 다른 필터를 가짐)
    CategoryOptionMappingGraph
    ├── graph: Map<RootCategory, ArrayList<CategoryOptionMappingNode>>
    └── CategoryOptionMappingNode
        ├── rootCategory: RootCategory
        ├── categoryOption: CategoryOption
        └── filters: ArrayList<CategoryOptionFilter>
    ```
  - 카테고리 조회 API 구현

# 🧪 Testing Details
- **테스트 코드 및 결과:** 작성한 테스트 코드와 주요 테스트 케이스를 설명하고, 통과된 테스트 결과를 요약해 주세요.
  - 기존 테스트 통과 완료
  <img width="861" height="441" alt="image" src="https://github.com/user-attachments/assets/79df4f6b-d05d-41a6-b29c-31dbe823877d" />
  <img width="863" height="220" alt="image" src="https://github.com/user-attachments/assets/80c8cb2d-e65e-4ad6-928a-b9b2b863918f" />


# 👀 Checkpoints for Reviewers
- **리뷰 시 확인할 사항:** 
  - 루트 카테고리, 서브 카테고리, 옵션 등은 고정값으로 판단해서 enum으로 설계 하였습니다.
  - 카테고리-옵션-필터의 관계는 유동성이 있다고 생각해서, `CategoryOptionMappingGraph`를 통해 그래프 로직으로 관계를 맺어주었습니다. 인메모리에서는 관계 표현에 대해 Map 기반의 그래프 구조가 가장 어울릴 것 같아 구현했는데, 다른 방법이 있을까요?
  - 필터도 객체로 분리하고 싶었는데, 더 시간이 들 것 같아서 일단 `CategoryOptionMappingNode` 처럼 설계했습니다.

# 🎯 Related Issues
- closes #15
