### PR TITLE
fix: Gradle 빌드 오류 해결 및 Member 엔티티 수정

### DIFF
--- a/src/main/java/subscribenlike/mogupick/global/config/JpaConfig.java
+++ b/src/main/java/subscribenlike/mogupick/global/config/JpaConfig.java
@@ -1,0 +1,29 @@
+package subscribenlike.mogupick.global.config;
+
+import jakarta.persistence.EntityManagerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.orm.jpa.JpaVendorAdapter;
+import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
+import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
+
+import javax.sql.DataSource;
+
+@Configuration
+public class JpaConfig {
+
+    @Bean
+    public LocalContainerEntityManagerFactoryBean entityManagerFactory(DataSource dataSource) {
+        LocalContainerEntityManagerFactoryBean em = new LocalContainerEntityManagerFactoryBean();
+        em.setDataSource(dataSource);
+        em.setPackagesToScan("subscribenlike.mogupick"); // 패키지명을 실제 패키지로 변경
+
+        JpaVendorAdapter vendorAdapter = new HibernateJpaVendorAdapter();
+        em.setJpaVendorAdapter(vendorAdapter);
+
+        // EntityManagerFactory 인터페이스를 명시적으로 설정하여 충돌 해결
+        em.setEntityManagerFactoryInterface(EntityManagerFactory.class);
+
+        return em;
+    }
+}

--- a/src/main/java/subscribenlike/mogupick/member/domain/Member.java
+++ b/src/main/java/subscribenlike/mogupick/member/domain/Member.java
@@ -42,7 +42,7 @@ public class Member extends BaseEntity {
 
     @Builder
     public Member(Long id, String name, String email, String password, String phoneNumber, LocalDate birthDate,
-                  boolean isAccepted, MemberRole role) {
+                  boolean isAccepted, MemberRole role, String provider, String nickname) {
         this.id = id;
         this.name = name;
         this.email = email;


### PR DESCRIPTION
# 🚀 What’s this PR about?
- **작업 내용 요약:** Gradle 빌드 오류와 관련된 컴파일 문제를 해결하여, 애플리케이션이 정상적으로 구동되도록 수정합니다.

# 🛠️ What’s been done?
- Member.java 수정: @Builder 어노테이션이 붙은 생성자에서 누락되었던 nickname, provider 파라미터를 추가하여 컴파일 오류를 해결했습니다.
- JpaConfig.java 추가: 의존성 충돌로 인해 발생하는 getSchemaManager() 메소드의 리턴 타입 불일치 문제를 해결하기 위해, EntityManagerFactory의 프록시 인터페이스를 표준 JPA 인터페이스(jakarta.persistence.EntityManagerFactory)로 명시적으로 지정하는 설정 클래스를 추가했습니다.

# 🧪 Testing Details
- **테스트 코드 및 결과:** 작성한 테스트 코드와 주요 테스트 케이스를 설명하고, 통과된 테스트 결과를 요약해 주세요.
  - 테스트 커버리지 및 성공 여부
  - 추가적인 검증이 필요한 시나리오

# 👀 Checkpoints for Reviewers
- **리뷰 시 확인할 사항:** 
  - 확인이 필요한 부분 (ex. 코드 스타일, 로직 등)
  - 추가로 논의하고 싶은 주제나 우려 사항
  - 리뷰어의 의견을 듣고 싶은 내용

# 🎯 Related Issues
- closes #42 
