### PR TITLE
fix: SecurityConfig 빈 주입 오류 및 Member 테스트 생성자 추가

### DIFF
--- a/src/main/java/subscribenlike/mogupick/global/config/CorsConfig.java
+++ b/src/main/java/subscribenlike/mogupick/global/config/CorsConfig.java
@@ -5,6 +5,7 @@ import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -21,6 +22,7 @@ public class CorsConfig {
     private List<String> allowedMethods;
     private List<String> allowedHeaders;
 
+    @Primary
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();

--- a/src/main/java/subscribenlike/mogupick/member/domain/Member.java
+++ b/src/main/java/subscribenlike/mogupick/member/domain/Member.java
@@ -58,6 +58,17 @@ public class Member extends BaseEntity {
         this.profileImage = profileImage;
     }
 
+    public Member(String name, String email, String password, String phoneNumber, LocalDate birthDate,
+                  boolean isAccepted, MemberRole role) {
+        this.name = name;
+        this.email = email;
+        this.password = password;
+        this.phoneNumber = phoneNumber;
+        this.birthDate = birthDate;
+        this.isAccepted = isAccepted;
+        this.role = role;
+    }
+
     public void updateRefreshToken(String refreshToken) {
         this.refreshToken = refreshToken;
     }


### PR DESCRIPTION
# 🚀 What’s this PR about?
- **작업 내용 요약:** 개발 환경에서 발생한 애플리케이션 실행 오류와 테스트 코드 컴파일 오류를 해결합니다.

# 🛠️ What’s been done?
- CorsConfig.java 수정: CORS 설정 Bean 주입 시 모호성으로 인해 SecurityConfig가 정상적으로 생성되지 않던 문제를 @Primary 어노테이션을 추가하여 해결했습니다.
- Member.java 수정: Fixture에서 사용하던 생성자가 누락되어 발생한 컴파일 오류를 해결하기 위해 해당 생성자를 다시 추가했습니다.

# 🧪 Testing Details
- **테스트 코드 및 결과:** 
- 수정 후, 로컬 환경에서 Application run failed 에러 없이 애플리케이션이 정상적으로 구동되는 것을 확인했습니다.

# 👀 Checkpoints for Reviewers
- **리뷰 시 확인할 사항:** 
  - 확인이 필요한 부분 (ex. 코드 스타일, 로직 등)
  - 추가로 논의하고 싶은 주제나 우려 사항
  - 리뷰어의 의견을 듣고 싶은 내용

# 🎯 Related Issues
- closes #53 