### PR TITLE
feat: CustomUserDetails 구현하여 인증 정보에 memberId 추가

### DIFF
--- a/src/main/java/subscribenlike/mogupick/global/security/CustomUserDetails.java
+++ b/src/main/java/subscribenlike/mogupick/global/security/CustomUserDetails.java
@@ -1,0 +1,18 @@
+package subscribenlike.mogupick.global.security;
+
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+
+import java.util.Collection;
+
+@Getter
+public class CustomUserDetails extends User {
+
+    private final Long memberId;
+
+    public CustomUserDetails(Long memberId, String username, String password, Collection<? extends GrantedAuthority> authorities) {
+        super(username, password, authorities);
+        this.memberId = memberId;
+    }
+}

--- a/src/main/java/subscribenlike/mogupick/member/controller/MemberController.java
+++ b/src/main/java/subscribenlike/mogupick/member/controller/MemberController.java
@@ -3,9 +3,9 @@ package subscribenlike.mogupick.member.controller;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 import subscribenlike.mogupick.global.dto.ApiResponse;
+import subscribenlike.mogupick.global.security.CustomUserDetails;
 import subscribenlike.mogupick.member.dto.MemberResponse;
 import subscribenlike.mogupick.member.dto.MemberUpdateRequest;
 import subscribenlike.mogupick.member.service.MemberService;
@@ -13,21 +13,22 @@ import subscribenlike.mogupick.member.service.MemberService;
 @RestController
 @RequestMapping("/api/v1/members")
 @RequiredArgsConstructor
-public class MemberController {
+class MemberController {
 
     private final MemberService memberService;
 
     @GetMapping("/me")
-    public ApiResponse<MemberResponse> getMyInfo(@AuthenticationPrincipal UserDetails userDetails) {
-        String email = userDetails.getUsername();
+    public ApiResponse<MemberResponse> getMyInfo(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        String email = userDetails.getUsername(); 
         MemberResponse memberInfo = memberService.getMemberInfo(email);
         return ApiResponse.success(memberInfo);
     }
 
     @PatchMapping("/me")
     public ApiResponse<Void> updateMyNickname(
-            @AuthenticationPrincipal UserDetails userDetails,
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @Valid @RequestBody MemberUpdateRequest request) {
+        Long memberId = userDetails.getMemberId();
         String email = userDetails.getUsername();
         memberService.updateNickname(email, request);
         return ApiResponse.success(null);


### PR DESCRIPTION
# 🚀 What’s this PR about?
- **작업 내용 요약:** @AuthenticationPrincipal을 통해 memberId를 직접 조회할 수 있도록 변경.

# 🛠️ What’s been done?
- CustomUserDetails.java 추가: Spring Security의 UserDetails를 확장하여 memberId 필드를 포함하는 CustomUserDetails 클래스를 생성했습니다.
- JwtProvider.java 수정:
  - JWT 생성 시 memberId를 클레임으로 포함하도록 generateToken 메소드를 수정했습니다.
  - 토큰을 해석할 때 memberId 클레임을 읽어 CustomUserDetails 객체를 생성하도록 getAuthentication 메소드를 수정했습니다.
 - MemberController.java 수정:
  - @AuthenticationPrincipal 사용 시 기존 UserDetails 대신 CustomUserDetails를 직접 주입받도록 변경하여, DB 조회 없이 memberId를 바로 사용할 수 있도록 개선했습니다.

# 🧪 Testing Details
- **테스트 코드 및 결과:** 리팩토링 이후, 관련 기능들이 모두 정상적으로 동작하는 것을 확인했습니다.
- 기능 테스트: 로그인, 로그아웃, 내 정보 조회/수정 기능이 모두 이전과 동일하게 정상 동작하는 것을 Postman으로 확인했습니다.
- 성능 개선 확인: MemberController에 디버깅 코드를 추가하여, @AuthenticationPrincipal로 주입받은 CustomUserDetails 객체에서 DB 조회 없이 memberId를 성공적으로 가져오는 것을 확인했습니다.

# 👀 Checkpoints for Reviewers
- **리뷰 시 확인할 사항:** 
  - 확인이 필요한 부분 (ex. 코드 스타일, 로직 등)
  - 추가로 논의하고 싶은 주제나 우려 사항
  - 리뷰어의 의견을 듣고 싶은 내용

# 🎯 Related Issues
- closes #67 
