### PR TITLE
feat : 리뷰 좋아요 생성/제거 기능 추가

### DIFF
--- a/src/main/java/subscribenlike/mogupick/review/common/ReviewSuccessCode.java
+++ b/src/main/java/subscribenlike/mogupick/review/common/ReviewSuccessCode.java
@@ -10,7 +10,9 @@ import subscribenlike.mogupick.common.success.SuccessCode;
 public enum ReviewSuccessCode implements SuccessCode {
 
     REVIEW_CREATED(HttpStatus.CREATED, "리뷰가 성공적으로 작성되었습니다."),
-    PRODUCT_REVIEWS_FETCHED(HttpStatus.OK, "상품의 리뷰 목록을 조회하였습니다.");
+    PRODUCT_REVIEWS_FETCHED(HttpStatus.OK, "상품의 리뷰 목록을 조회하였습니다."),
+    REVIEW_LIKE_ADDED(HttpStatus.CREATED, "리뷰에 좋아요를 추가하였습니다."),
+    REVIEW_LIKE_REMOVED(HttpStatus.OK, "리뷰 좋아요를 제거하였습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/subscribenlike/mogupick/review/controller/ReviewController.java
+++ b/src/main/java/subscribenlike/mogupick/review/controller/ReviewController.java
@@ -75,4 +75,54 @@ public class ReviewController {
                 .status(200)
                 .body(SuccessResponse.from(ReviewSuccessCode.PRODUCT_REVIEWS_FETCHED, response));
     }
+
+    @Operation(summary = "리뷰 좋아요 추가", description = "특정 리뷰에 좋아요를 추가합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "201",
+                    description = "리뷰 좋아요 추가 성공"
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "리뷰 또는 회원을 찾을 수 없음"
+            ),
+            @ApiResponse(
+                    responseCode = "409",
+                    description = "이미 해당 리뷰에 좋아요를 눌렀음"
+            )
+    })
+    @PostMapping("/{reviewId}/likes")
+    public ResponseEntity<SuccessResponse<Void>> addLikeToReview(
+            @PathVariable Long reviewId,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        reviewService.addLikeToReview(reviewId, userDetails.getMemberId());
+
+        return ResponseEntity
+                .status(ReviewSuccessCode.REVIEW_LIKE_ADDED.getStatus())
+                .body(SuccessResponse.from(ReviewSuccessCode.REVIEW_LIKE_ADDED));
+    }
+
+    @Operation(summary = "리뷰 좋아요 제거", description = "특정 리뷰에 대한 좋아요를 제거합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "리뷰 좋아요 제거 성공"
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "리뷰 또는 회원을 찾을 수 없음, 또는 좋아요가 존재하지 않음"
+            )
+    })
+    @DeleteMapping("/{reviewId}/likes")
+    public ResponseEntity<SuccessResponse<Void>> removeLikeFromReview(
+            @PathVariable Long reviewId,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        reviewService.removeLikeFromReview(reviewId, userDetails.getMemberId());
+
+        return ResponseEntity
+                .status(ReviewSuccessCode.REVIEW_LIKE_REMOVED.getStatus())
+                .body(SuccessResponse.from(ReviewSuccessCode.REVIEW_LIKE_REMOVED));
+    }
 }

--- a/src/main/java/subscribenlike/mogupick/review/service/ReviewService.java
+++ b/src/main/java/subscribenlike/mogupick/review/service/ReviewService.java
@@ -11,7 +11,10 @@ import subscribenlike.mogupick.member.domain.Member;
 import subscribenlike.mogupick.member.repository.MemberRepository;
 import subscribenlike.mogupick.product.domain.Product;
 import subscribenlike.mogupick.product.repository.ProductRepository;
+import subscribenlike.mogupick.review.common.ReviewErrorCode;
+import subscribenlike.mogupick.review.common.ReviewException;
 import subscribenlike.mogupick.review.domain.Review;
+import subscribenlike.mogupick.review.domain.ReviewLike;
 import subscribenlike.mogupick.review.domain.ReviewMedia;
 import subscribenlike.mogupick.review.model.CreateReviewRequest;
 import subscribenlike.mogupick.review.model.FetchProductReviewsResponse;
@@ -170,5 +173,32 @@ public class ReviewService {
                 .productReviewCount(reviewCount)
                 .reviews(reviewPage.getContent())
                 .build();
+    }
+
+    @Transactional
+    public void addLikeToReview(Long reviewId, Long memberId) {
+        Member member = memberRepository.findOrThrow(memberId);
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new ReviewException(ReviewErrorCode.REVIEW_NOT_FOUND));
+
+        // 이미 좋아요가 있는지 확인
+        boolean alreadyLiked = reviewLikeRepository.findByReviewIdAndMemberId(reviewId, memberId).isPresent();
+        if (alreadyLiked) {
+            throw new ReviewException(ReviewErrorCode.REVIEW_LIKE_ALREADY_EXISTS);
+        }
+
+        // 좋아요 생성 및 저장
+        ReviewLike reviewLike = new ReviewLike(review, member);
+        reviewLikeRepository.save(reviewLike);
+    }
+
+    @Transactional
+    public void removeLikeFromReview(Long reviewId, Long memberId) {
+        // 좋아요가 있는지 확인
+        ReviewLike reviewLike = reviewLikeRepository.findByReviewIdAndMemberId(reviewId, memberId)
+                .orElseThrow(() -> new ReviewException(ReviewErrorCode.REVIEW_LIKE_NOT_FOUND));
+
+        // 좋아요 삭제
+        reviewLikeRepository.delete(reviewLike);
     }
 }


### PR DESCRIPTION
## 🚀 What’s this PR about?
**리뷰 좋아요 기능의 에러 처리 개선 및 상품 검색 응답 구조 수정**

- 리뷰 좋아요 생성/제거 기능 추가

## 🛠️ What’s been done?
- 리뷰 좋아요 생성/제거 api 구현

## 🧪 Testing Details
**테스트 코드 및 결과:**
- `ReviewServiceTest.java`에 새로운 에러 처리 기능에 대한 포괄적인 테스트 케이스들이 작성되어 있습니다:
  - 리뷰 좋아요 추가 성공 케이스
  - 중복 좋아요 시 예외 발생 테스트
  - 좋아요 제거 성공 케이스
  - 존재하지 않는 좋아요 제거 시 예외 발생 테스트
  - 존재하지 않는 리뷰에 대한 좋아요 추가/제거 시 예외 발생 테스트
 
## 👀 Checkpoints for Reviewers
**리뷰 시 확인할 사항:** 따로 없습니다.

## 🎯 Related Issues
- closes #72 
