### PR TITLE
s3이미지 업로드 구현 및 상품  검색조회기능 썸네일 조회수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
 
     // AWS S3
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
     implementation platform('software.amazon.awssdk:bom:2.26.3')
     implementation 'software.amazon.awssdk:s3'
 

--- a/src/main/java/subscribenlike/mogupick/common/config/S3Config.java
+++ b/src/main/java/subscribenlike/mogupick/common/config/S3Config.java
@@ -1,5 +1,10 @@
 package subscribenlike.mogupick.common.config;
 
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -11,10 +16,20 @@ public class S3Config {
     @Value("${spring.cloud.aws.region.static}")
     private String region;
 
+    @Value("${spring.cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${spring.cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
     @Bean
-    public S3Client s3Client() {
-        return S3Client.builder()
-                .region(Region.of(region))
+    public AmazonS3 amazonS3() {
+        AWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+
+        return AmazonS3ClientBuilder
+                .standard()
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .withRegion(region)
                 .build();
     }
 }

--- a/src/main/java/subscribenlike/mogupick/common/utils/S3Service.java
+++ b/src/main/java/subscribenlike/mogupick/common/utils/S3Service.java
@@ -1,48 +1,116 @@
 package subscribenlike.mogupick.common.utils;
 
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Service;
-import org.springframework.web.multipart.MultipartFile;
-import software.amazon.awssdk.core.sync.RequestBody;
-import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
-import software.amazon.awssdk.services.s3.model.PutObjectRequest;
-
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.util.IOUtils;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLDecoder;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
 
-@Service
+@Slf4j
+@RequiredArgsConstructor
+@Component
 public class S3Service {
-    private final S3Client s3Client;
-    private final String bucketName;
-    private final String region;
+    private final AmazonS3 amazonS3;
 
-    public S3Service(S3Client s3Client,
-                     @Value("${spring.cloud.aws.s3.bucket}") String bucketName,
-                     @Value("${spring.cloud.aws.region.static}") String region) {
-        this.s3Client = s3Client;
-        this.bucketName = bucketName;
-        this.region = region;
+    @Value("${cloud.aws.s3.bucketName}")
+    private String bucketName;
+
+    public String upload(MultipartFile image) {
+        if (image.isEmpty() || Objects.isNull(image.getOriginalFilename())) {
+            throw new IllegalArgumentException("이미지가 없습니다.");
+        }
+        return this.uploadImage(image);
     }
 
-    public String uploadFile(MultipartFile file) {
-        try{
-            String fileName = UUID.randomUUID() + "-" + file.getOriginalFilename();
+    private String uploadImage(MultipartFile image) {
+        this.validateImageFileExtention(Objects.requireNonNull(image.getOriginalFilename()));
+        try {
+            return this.uploadImageToS3(image);
+        } catch (IOException e) {
+            throw new IllegalArgumentException("이미지가 없습니다.");
+        }
+    }
 
-            PutObjectRequest putObjectRequest = PutObjectRequest.builder()
-                    .bucket(bucketName)
-                    .key(fileName)
-                    .contentType(file.getContentType())
-                    .acl(ObjectCannedACL.PUBLIC_READ)
-                    .build();
+    private void validateImageFileExtention(String filename) {
+        int lastDotIndex = filename.lastIndexOf(".");
+        if (lastDotIndex == -1) {
+            throw new IllegalArgumentException("지원하지 않는 확장자 입니다.");
+        }
 
-            s3Client.putObject(putObjectRequest,
-                    RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
+        String extention = filename.substring(lastDotIndex + 1).toLowerCase();
+        List<String> allowedExtentionList = Arrays.asList("jpg", "jpeg", "png", "gif");
 
-            return "https://" + bucketName + ".s3." + region + ".amazonaws.com/" + fileName;
-        }catch (IOException e){
-            throw new RuntimeException("Failed to upload file to S3", e);
+        if (!allowedExtentionList.contains(extention)) {
+            throw new IllegalArgumentException("지원하지 않는 확장자 입니다.");
+        }
+    }
+
+    private String uploadImageToS3(MultipartFile image) throws IOException {
+        String originalFilename = image.getOriginalFilename(); // 원본 파일 명
+        assert originalFilename != null;
+        String extention = originalFilename.substring(originalFilename.lastIndexOf(".")); // 확장자 명
+
+        String s3FileName = UUID.randomUUID().toString().substring(0, 10) + originalFilename; // 변경된 파일 명
+
+        InputStream is = image.getInputStream();
+        byte[] bytes = IOUtils.toByteArray(is);
+
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentType("image/" + extention.replace(".", "")); // 확장자 점 제거
+        metadata.setContentLength(bytes.length);
+        ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(bytes);
+
+        try {
+            PutObjectRequest putObjectRequest =
+                    new PutObjectRequest(bucketName, s3FileName, byteArrayInputStream, metadata)
+                            .withCannedAcl(CannedAccessControlList.PublicRead);
+            amazonS3.putObject(putObjectRequest); // put image to S3
+        } catch (Exception e) {
+            log.error("S3 이미지 업로드 실패: filename={}, error={}", originalFilename, e.getMessage(), e);
+            throw new IllegalArgumentException("S3 이미지 업로드에 실패했습니다.");
+        } finally {
+            byteArrayInputStream.close();
+            is.close();
+        }
+
+        return amazonS3.getUrl(bucketName, s3FileName).toString();
+    }
+
+    public void deleteImageFromS3(String imageAddress) {
+        String key = getKeyFromImageAddress(imageAddress);
+        try {
+            amazonS3.deleteObject(new DeleteObjectRequest(bucketName, key));
+        } catch (Exception e) {
+            log.error("S3 이미지 삭제 실패: key={}, error={}", key, e.getMessage(), e);
+            throw new IllegalArgumentException("S3 이미지 삭제에 실패했습니다.");
+        }
+    }
+
+    private String getKeyFromImageAddress(String imageAddress) {
+        try {
+            URL url = new URL(imageAddress);
+            String decodingKey = URLDecoder.decode(url.getPath(), "UTF-8");
+            return decodingKey.substring(1); // 맨 앞의 '/' 제거
+        } catch (MalformedURLException | UnsupportedEncodingException e) {
+            log.error("이미지 주소 변환 실패: imageAddress={}, error={}", imageAddress, e.getMessage(), e);
+            throw new IllegalArgumentException("잘못된 이미지 주소입니다.");
         }
     }
 }
-

--- a/src/main/java/subscribenlike/mogupick/searchKeyword/dto/SearchProductResponse.java
+++ b/src/main/java/subscribenlike/mogupick/searchKeyword/dto/SearchProductResponse.java
@@ -1,6 +1,7 @@
 package subscribenlike.mogupick.searchKeyword.dto;
 
 import subscribenlike.mogupick.product.domain.Product;
+import subscribenlike.mogupick.product.domain.ProductMedia;
 
 public record SearchProductResponse(
         Long id,
@@ -11,8 +12,9 @@ public record SearchProductResponse(
         double rating,
         int reviewCount
 ) {
-    public static SearchProductResponse of(Product product, double rating, int reviewCount) {
-        return new SearchProductResponse(product.getId(), product.getName(), product.getPrice(), product.getImageUrl(),
+    public static SearchProductResponse of(Product product, ProductMedia productMedia, double rating, int reviewCount) {
+        return new SearchProductResponse(product.getId(), product.getName(), product.getPrice(),
+                productMedia.getImageUrl(),
                 product.getBrandName(), rating, reviewCount);
     }
 }

--- a/src/main/java/subscribenlike/mogupick/searchKeyword/service/SearchKeywordService.java
+++ b/src/main/java/subscribenlike/mogupick/searchKeyword/service/SearchKeywordService.java
@@ -16,6 +16,8 @@ import org.springframework.transaction.annotation.Transactional;
 import subscribenlike.mogupick.member.domain.Member;
 import subscribenlike.mogupick.member.repository.MemberRepository;
 import subscribenlike.mogupick.product.domain.Product;
+import subscribenlike.mogupick.product.domain.ProductMedia;
+import subscribenlike.mogupick.product.repository.ProductMediaRepository;
 import subscribenlike.mogupick.product.repository.ProductRepository;
 import subscribenlike.mogupick.recentSearchKeyword.domain.RecentSearchKeyword;
 import subscribenlike.mogupick.recentSearchKeyword.repository.RecentSearchKeywordRepository;
@@ -39,6 +41,7 @@ public class SearchKeywordService {
     private final SearchKeywordRepository searchKeywordRepository;
     private final RecentSearchKeywordRepository recentSearchKeywordRepository;
     private final ProductRepository productRepository;
+    private final ProductMediaRepository productMediaRepository;
     private final ReviewRepository reviewRepository;
     private final StringRedisTemplate redis;
     private final MemberRepository memberRepository;
@@ -65,9 +68,14 @@ public class SearchKeywordService {
         return productList.stream()
                 .map(product -> {
                     List<Review> reviews = findReviewByProductId(product.getId());
-                    return SearchProductResponse.of(product, calculateRate(reviews), reviews.size());
+                    return SearchProductResponse.of(product, findThumbnailByProductId(product.getId()),
+                            calculateRate(reviews), reviews.size());
                 })
                 .toList();
+    }
+
+    private ProductMedia findThumbnailByProductId(Long productId) {
+        return productMediaRepository.findByProductId(productId).get(0);
     }
 
     private List<Review> findReviewByProductId(Long productId) {


### PR DESCRIPTION
# 🚀 What’s this PR about?
- **작업 내용 요약:** 이 PR에서 해결하거나 추가한 내용을 간략히 설명해 주세요.
- s3이미지 업로드 구현 및 상품  검색조회기능 썸네일 조회수정

# 🛠️ What’s been done?
- 주요 변경사항을 상세히 기술하세요. (예: 새로운 기능 추가, 버그 수정, 코드 리팩토링 등)
  -  s3이미지 업로드 구현
      - MultipartFile 형태로 받은 객체를 String 형태의 이미지 url로 변환하는 upload메서드 구현
      - "jpg", "jpeg", "png", "gif" 이 4개의 확장자가 아닐경우 예외처리
      - "." 이후에 확장자가 없거나 "." 이 없을경우 예외처리
  -  검색조회기능 썸네일 조회수정
      - 검색 결과의 상품 Id 값으로 이미지들 조회 후 첫번째 사진을 썸네일로 사용

# 🧪 Testing Details
- **테스트 코드 및 결과:** 작성한 테스트 코드와 주요 테스트 케이스를 설명하고, 통과된 테스트 결과를 요약해 주세요.
  - 테스트 커버리지 및 성공 여부
  - 추가적인 검증이 필요한 시나리오

# 👀 Checkpoints for Reviewers
- **리뷰 시 확인할 사항:** 
  - 확인이 필요한 부분 (ex. 코드 스타일, 로직 등)
  - 추가로 논의하고 싶은 주제나 우려 사항
  - 리뷰어의 의견을 듣고 싶은 내용
  - @0-tae 기존 컨트롤러 코드에 첨부한 코드를 파라미터로 추가해주시면 해결 될 것 같습니다!
  - 또한 서비스 레이어에서 컨트롤러에서 받은 image를 `s3.upload(image)` 메서드를 사용하게되면 url 형태로 String 값을 반환해줘서 사용해서 **productMedia** 객체를 저장하시면 될 것 같습니다!
```java
@PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
    public ResponseEntity<SuccessResponse<Void>> createProduct(
            @ModelAttribute CreateProductRequest request) throws IOException {

        productService.createProduct(request);

        return ResponseEntity
                .status(ProductSuccessCode.PRODUCT_CREATED.getStatus())
                .body(SuccessResponse.from(ProductSuccessCode.PRODUCT_CREATED));
    }
```

```java
@RequestPart(value = "image", required = false) MultipartFile image // 하나만 등록할 경우
@RequestPart(value = "image", required = false) List<MultipartFile> images// 여러개를 등록할 경우
```

# 🎯 Related Issues
- closes #51 
