### PR TITLE
feat: 결제 예정 알림 스케줄러 구현

### DIFF
--- a/src/main/java/subscribenlike/mogupick/MogupickApplication.java
+++ b/src/main/java/subscribenlike/mogupick/MogupickApplication.java
@@ -3,9 +3,11 @@ package subscribenlike.mogupick;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 public class MogupickApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/subscribenlike/mogupick/notification/domain/Notification.java
+++ b/src/main/java/subscribenlike/mogupick/notification/domain/Notification.java
@@ -1,11 +1,8 @@
 package subscribenlike.mogupick.notification.domain;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import subscribenlike.mogupick.common.domain.BaseEntity;
@@ -15,16 +12,36 @@ import subscribenlike.mogupick.member.domain.Member;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Notification extends BaseEntity {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(nullable = false)
     private String content;
 
-    private Boolean isRead;
+    private String url;
 
+    @Column(nullable = false)
+    private Boolean isRead = false;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
     private NotificationType notificationType;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
     private Member member;
+
+    @Builder
+    public Notification(Member member, String content, String url, NotificationType notificationType) {
+        this.member = member;
+        this.content = content;
+        this.url = url;
+        this.notificationType = notificationType;
+    }
+
+    public void read() {
+        this.isRead = true;
+    }
 }

--- a/src/main/java/subscribenlike/mogupick/notification/domain/NotificationType.java
+++ b/src/main/java/subscribenlike/mogupick/notification/domain/NotificationType.java
@@ -1,6 +1,16 @@
 package subscribenlike.mogupick.notification.domain;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum NotificationType {
-    WARNING;
-    // todo 내용 추가논의 필요
+
+    DELIVERY_STARTED("배송 시작 알림"),
+    PAYMENT_REMINDER("결제 예정 알림"),
+    PAYMENT_COMPLETED("결제 완료 알림"),
+    NEW_REVIEW("새로운 리뷰 알림");
+
+    private final String description;
 }

--- a/src/main/java/subscribenlike/mogupick/notification/repository/NotificationRepository.java
+++ b/src/main/java/subscribenlike/mogupick/notification/repository/NotificationRepository.java
@@ -1,0 +1,7 @@
+package subscribenlike.mogupick.notification.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import subscribenlike.mogupick.notification.domain.Notification;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+}

--- a/src/main/java/subscribenlike/mogupick/notification/scheduler/NotificationScheduler.java
+++ b/src/main/java/subscribenlike/mogupick/notification/scheduler/NotificationScheduler.java
@@ -1,0 +1,46 @@
+package subscribenlike.mogupick.notification.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import subscribenlike.mogupick.notification.domain.NotificationType;
+import subscribenlike.mogupick.notification.service.NotificationService;
+import subscribenlike.mogupick.subscription.domain.Subscription;
+import subscribenlike.mogupick.subscription.repository.SubscriptionRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotificationScheduler {
+
+    private final NotificationService notificationService;
+    private final SubscriptionRepository subscriptionRepository;
+
+    @Scheduled(cron = "0 0 9 * * *")
+    public void sendPaymentReminderNotifications() {
+        log.info("결제 3일 전 알림 스케줄러를 시작합니다.");
+
+        LocalDate targetDate = LocalDate.now().plusDays(3);
+
+        List<Subscription> subscriptions = subscriptionRepository.findByNextPaymentDate(targetDate);
+
+        for (Subscription subscription : subscriptions) {
+            String content = String.format(
+                    "'%s' 상품의 결제 예정일이 3일 남았습니다.",
+                    subscription.getProduct().getName()
+            );
+
+            notificationService.createNotification(
+                    subscription.getMember(),
+                    NotificationType.PAYMENT_REMINDER,
+                    content,
+                    "/my-page/subscriptions"
+            );
+        }
+        log.info("총 {}개의 결제 3일 전 알림 생성을 완료했습니다.", subscriptions.size());
+    }
+}

--- a/src/main/java/subscribenlike/mogupick/notification/service/NotificationService.java
+++ b/src/main/java/subscribenlike/mogupick/notification/service/NotificationService.java
@@ -1,0 +1,27 @@
+package subscribenlike.mogupick.notification.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import subscribenlike.mogupick.member.domain.Member;
+import subscribenlike.mogupick.notification.domain.Notification;
+import subscribenlike.mogupick.notification.domain.NotificationType;
+import subscribenlike.mogupick.notification.repository.NotificationRepository;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class NotificationService {
+
+    private final NotificationRepository notificationRepository;
+
+    public void createNotification(Member member, NotificationType type, String content, String url) {
+        Notification notification = Notification.builder()
+                .member(member)
+                .notificationType(type)
+                .content(content)
+                .url(url)
+                .build();
+        notificationRepository.save(notification);
+    }
+}

--- a/src/main/java/subscribenlike/mogupick/subscription/domain/Subscription.java
+++ b/src/main/java/subscribenlike/mogupick/subscription/domain/Subscription.java
@@ -5,7 +5,10 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import subscribenlike.mogupick.common.domain.BaseEntity;
+import subscribenlike.mogupick.member.domain.Member;
 import subscribenlike.mogupick.product.domain.Product;
+
+import java.time.LocalDate;
 
 @Entity
 @Getter
@@ -17,4 +20,10 @@ public class Subscription extends BaseEntity {
 
     @ManyToOne
     private Product product;
+
+    @ManyToOne
+    private Member member;
+
+    private LocalDate nextPaymentDate;
+
 }

--- a/src/main/java/subscribenlike/mogupick/subscription/repository/SubscriptionRepository.java
+++ b/src/main/java/subscribenlike/mogupick/subscription/repository/SubscriptionRepository.java
@@ -1,0 +1,12 @@
+package subscribenlike.mogupick.subscription.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import subscribenlike.mogupick.subscription.domain.Subscription;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface SubscriptionRepository extends JpaRepository<Subscription, Long> {
+
+    List<Subscription> findByNextPaymentDate(LocalDate nextPaymentDate);
+}


### PR DESCRIPTION
# 🚀 What’s this PR about?
- **작업 내용 요약:** '결제 3일 전'인 구독을 매일 자동으로 찾아내 사용자에게 알림을 생성하는 스케줄러 기능을 구현합니다.

# 🛠️ What’s been done?
- @EnableScheduling 추가: Spring Boot 애플리케이션에 스케줄링 기능을 활성화했습니다.
- Notification 도메인 추가: 알림 데이터를 저장하기 위한 Notification 엔티티, NotificationType Enum, NotificationRepository를 생성했습니다.
- Subscription 도메인 기반 추가: 스케줄러가 결제일을 조회할 수 있도록 최소한의 Subscription 엔티티와 findByNextPaymentDate 메소드가 포함된 SubscriptionRepository를 생성했습니다.
- NotificationService 추가: 다른 기능에서 공통으로 사용할 createNotification 메소드를 구현했습니다.
- NotificationScheduler 추가: 매일 오전 9시에 동작하여 결제 예정일이 3일 남은 구독을 찾아 알림을 생성하는 스케줄러를 구현했습니다.

# 🧪 Testing Details
- **테스트 코드 및 결과:** 로컬 환경에서 스케줄러가 정상적으로 동작하는 것을 확인했습니다.

- DB에 next_payment_date가 3일 뒤인 테스트 데이터를 삽입했습니다.
- 스케줄러의 cron 표현식을 1분마다 실행되도록 임시 변경 후, 서버를 실행하여 1분 뒤 스케줄러가 동작하는 로그를 확인했습니다.
- 스케줄러 실행 후, notification 테이블에 해당 사용자에 대한 알림 데이터가 정상적으로 생성된 것을 확인했습니다.
<img width="1635" height="120" alt="스크린샷 2025-09-08 오전 2 31 21" src="https://github.com/user-attachments/assets/76ec71e6-3bbe-49f6-af57-b8e16ac2b166" />
<img width="1554" height="385" alt="스크린샷 2025-09-08 오전 2 30 59" src="https://github.com/user-attachments/assets/ed21c7c2-2f30-4efd-b886-4e7576cc42ac" />


# 👀 Checkpoints for Reviewers
- **리뷰 시 확인할 사항:** 
  - 확인이 필요한 부분 (ex. 코드 스타일, 로직 등)
  - 추가로 논의하고 싶은 주제나 우려 사항
  - 리뷰어의 의견을 듣고 싶은 내용

# 🎯 Related Issues
- closes #55 
