### PR TITLE
feat: 알림 목록 조회 및 읽음, 삭제 처리 API 구현

### DIFF
--- a/src/main/java/subscribenlike/mogupick/MogupickApplication.java
+++ b/src/main/java/subscribenlike/mogupick/MogupickApplication.java
@@ -3,9 +3,11 @@ package subscribenlike.mogupick;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 public class MogupickApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/subscribenlike/mogupick/notification/common/exception/NotificationErrorCode.java
+++ b/src/main/java/subscribenlike/mogupick/notification/common/exception/NotificationErrorCode.java
@@ -1,0 +1,35 @@
+package subscribenlike.mogupick.notification.common.exception;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import subscribenlike.mogupick.common.error.core.ErrorCode;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public enum NotificationErrorCode implements ErrorCode {
+
+    // 404 Not Found
+    NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 알림을 찾을 수 없습니다."),
+
+    // 403 Forbidden
+    FORBIDDEN_READ_NOTIFICATION(HttpStatus.FORBIDDEN, "해당 알림을 읽을 권한이 없습니다."),
+
+    ;
+
+    public static final String PREFIX = "[NOTIFICATION ERROR] ";
+
+    private final HttpStatus status;
+    private final String rawMessage;
+
+    @Override
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getMessage() {
+        return PREFIX + rawMessage;
+    }
+}

--- a/src/main/java/subscribenlike/mogupick/notification/common/exception/NotificationException.java
+++ b/src/main/java/subscribenlike/mogupick/notification/common/exception/NotificationException.java
@@ -1,0 +1,9 @@
+package subscribenlike.mogupick.notification.common.exception;
+
+import subscribenlike.mogupick.common.error.core.BaseException;
+
+public class NotificationException extends BaseException {
+    public NotificationException(NotificationErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/subscribenlike/mogupick/notification/common/success/NotificationSuccessCode.java
+++ b/src/main/java/subscribenlike/mogupick/notification/common/success/NotificationSuccessCode.java
@@ -1,0 +1,21 @@
+package subscribenlike.mogupick.notification.common.success;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import subscribenlike.mogupick.common.success.SuccessCode;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public enum NotificationSuccessCode implements SuccessCode {
+
+    // 200 OK
+    GET_NOTIFICATIONS_SUCCESS(HttpStatus.OK, "알림 목록 조회에 성공했습니다."),
+    READ_NOTIFICATION_SUCCESS(HttpStatus.OK, "알림 읽음 처리에 성공했습니다."),
+
+    ;
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/subscribenlike/mogupick/notification/common/success/NotificationSuccessCode.java
+++ b/src/main/java/subscribenlike/mogupick/notification/common/success/NotificationSuccessCode.java
@@ -13,6 +13,7 @@ public enum NotificationSuccessCode implements SuccessCode {
     // 200 OK
     GET_NOTIFICATIONS_SUCCESS(HttpStatus.OK, "알림 목록 조회에 성공했습니다."),
     READ_NOTIFICATION_SUCCESS(HttpStatus.OK, "알림 읽음 처리에 성공했습니다."),
+    DELETE_NOTIFICATION_SUCCESS(HttpStatus.OK, "알림 삭제에 성공했습니다."),
 
     ;
 

--- a/src/main/java/subscribenlike/mogupick/notification/controller/NotificationController.java
+++ b/src/main/java/subscribenlike/mogupick/notification/controller/NotificationController.java
@@ -1,0 +1,50 @@
+package subscribenlike.mogupick.notification.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import subscribenlike.mogupick.global.dto.GlobalResponse;
+import subscribenlike.mogupick.global.security.CustomUserDetails;
+import subscribenlike.mogupick.notification.common.success.NotificationSuccessCode;
+import subscribenlike.mogupick.notification.dto.NotificationResponse;
+import subscribenlike.mogupick.notification.service.NotificationService;
+
+import java.util.List;
+
+@Tag(name = "Notification", description = "알림 관련 API")
+@RestController
+@RequestMapping("/api/v1/notifications")
+@RequiredArgsConstructor
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    @Operation(summary = "내 알림 목록 조회", description = "현재 로그인된 사용자의 알림 목록을 최신순으로 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "알림 목록 조회 성공")
+    })
+    @SecurityRequirement(name = "bearerAuth")
+    @GetMapping
+    public GlobalResponse<List<NotificationResponse>> getMyNotifications(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        List<NotificationResponse> notifications = notificationService.getNotifications(userDetails.getMemberId());
+        return GlobalResponse.from(NotificationSuccessCode.GET_NOTIFICATIONS_SUCCESS, notifications);
+    }
+
+    @Operation(summary = "알림 읽음 처리", description = "특정 알림을 읽음 상태로 변경합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "알림 읽음 처리 성공")
+    })
+    @SecurityRequirement(name = "bearerAuth")
+    @PatchMapping("/{notificationId}")
+    public GlobalResponse<Void> readNotification(
+            @PathVariable Long notificationId,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        notificationService.readNotification(notificationId, userDetails.getMemberId());
+        return GlobalResponse.from(NotificationSuccessCode.READ_NOTIFICATION_SUCCESS);
+    }
+}

--- a/src/main/java/subscribenlike/mogupick/notification/controller/NotificationController.java
+++ b/src/main/java/subscribenlike/mogupick/notification/controller/NotificationController.java
@@ -47,4 +47,17 @@ public class NotificationController {
         notificationService.readNotification(notificationId, userDetails.getMemberId());
         return GlobalResponse.from(NotificationSuccessCode.READ_NOTIFICATION_SUCCESS);
     }
+
+    @Operation(summary = "알림 삭제", description = "특정 알림을 삭제합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "알림 삭제 성공")
+    })
+    @SecurityRequirement(name = "bearerAuth")
+    @DeleteMapping("/{notificationId}")
+    public GlobalResponse<Void> deleteNotification(
+            @PathVariable Long notificationId,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        notificationService.deleteNotification(notificationId, userDetails.getMemberId());
+        return GlobalResponse.from(NotificationSuccessCode.DELETE_NOTIFICATION_SUCCESS);
+    }
 }

--- a/src/main/java/subscribenlike/mogupick/notification/domain/Notification.java
+++ b/src/main/java/subscribenlike/mogupick/notification/domain/Notification.java
@@ -1,11 +1,8 @@
 package subscribenlike.mogupick.notification.domain;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import subscribenlike.mogupick.common.domain.BaseEntity;
@@ -15,16 +12,36 @@ import subscribenlike.mogupick.member.domain.Member;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Notification extends BaseEntity {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(nullable = false)
     private String content;
 
-    private Boolean isRead;
+    private String url;
 
+    @Column(nullable = false)
+    private Boolean isRead = false;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
     private NotificationType notificationType;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
     private Member member;
+
+    @Builder
+    public Notification(Member member, String content, String url, NotificationType notificationType) {
+        this.member = member;
+        this.content = content;
+        this.url = url;
+        this.notificationType = notificationType;
+    }
+
+    public void read() {
+        this.isRead = true;
+    }
 }

--- a/src/main/java/subscribenlike/mogupick/notification/domain/NotificationType.java
+++ b/src/main/java/subscribenlike/mogupick/notification/domain/NotificationType.java
@@ -7,10 +7,15 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum NotificationType {
 
-    DELIVERY_STARTED("배송 시작 알림"),
-    PAYMENT_REMINDER("결제 예정 알림"),
-    PAYMENT_COMPLETED("결제 완료 알림"),
-    NEW_REVIEW("새로운 리뷰 알림");
+    DELIVERY_STARTED("배송 시작 알림", "'%s' 상품의 배송이 시작되었습니다."),
+    PAYMENT_REMINDER("결제 예정 알림", "'%s' 상품의 결제 예정일이 3일 남았습니다."),
+    PAYMENT_COMPLETED("결제 완료 알림", "'%s' 상품 결제가 정상적으로 완료되었습니다."),
+    NEW_REVIEW("새로운 리뷰 알림", "'%s' 상품에 새로운 리뷰가 달렸습니다.");
 
     private final String description;
+    private final String contentTemplate;
+
+    public String createContent(String subject) {
+        return String.format(this.contentTemplate, subject);
+    }
 }

--- a/src/main/java/subscribenlike/mogupick/notification/domain/NotificationType.java
+++ b/src/main/java/subscribenlike/mogupick/notification/domain/NotificationType.java
@@ -1,6 +1,16 @@
 package subscribenlike.mogupick.notification.domain;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum NotificationType {
-    WARNING;
-    // todo 내용 추가논의 필요
+
+    DELIVERY_STARTED("배송 시작 알림"),
+    PAYMENT_REMINDER("결제 예정 알림"),
+    PAYMENT_COMPLETED("결제 완료 알림"),
+    NEW_REVIEW("새로운 리뷰 알림");
+
+    private final String description;
 }

--- a/src/main/java/subscribenlike/mogupick/notification/dto/NotificationResponse.java
+++ b/src/main/java/subscribenlike/mogupick/notification/dto/NotificationResponse.java
@@ -1,0 +1,28 @@
+package subscribenlike.mogupick.notification.dto;
+
+import lombok.Getter;
+import subscribenlike.mogupick.notification.domain.Notification;
+import subscribenlike.mogupick.notification.domain.NotificationType;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class NotificationResponse {
+
+    private final Long id;
+    private final String content;
+    private final String url;
+    private final boolean isRead;
+    private final NotificationType notificationType;
+    private final LocalDateTime createdAt;
+
+    // Notification 엔티티를 NotificationResponse DTO로 변환하는 생성자
+    public NotificationResponse(Notification notification) {
+        this.id = notification.getId();
+        this.content = notification.getContent();
+        this.url = notification.getUrl();
+        this.isRead = notification.getIsRead();
+        this.notificationType = notification.getNotificationType();
+        this.createdAt = notification.getCreatedAt();
+    }
+}

--- a/src/main/java/subscribenlike/mogupick/notification/repository/NotificationRepository.java
+++ b/src/main/java/subscribenlike/mogupick/notification/repository/NotificationRepository.java
@@ -1,0 +1,7 @@
+package subscribenlike.mogupick.notification.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import subscribenlike.mogupick.notification.domain.Notification;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+}

--- a/src/main/java/subscribenlike/mogupick/notification/repository/NotificationRepository.java
+++ b/src/main/java/subscribenlike/mogupick/notification/repository/NotificationRepository.java
@@ -3,5 +3,10 @@ package subscribenlike.mogupick.notification.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import subscribenlike.mogupick.notification.domain.Notification;
 
+import java.util.List;
+
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+    List<Notification> findByMemberIdOrderByCreatedAtDesc(Long memberId);
+
 }

--- a/src/main/java/subscribenlike/mogupick/notification/scheduler/NotificationScheduler.java
+++ b/src/main/java/subscribenlike/mogupick/notification/scheduler/NotificationScheduler.java
@@ -25,14 +25,11 @@ public class NotificationScheduler {
         log.info("결제 3일 전 알림 스케줄러를 시작합니다.");
 
         LocalDate targetDate = LocalDate.now().plusDays(3);
-
         List<Subscription> subscriptions = subscriptionRepository.findByNextPaymentDate(targetDate);
 
         for (Subscription subscription : subscriptions) {
-            String content = String.format(
-                    "'%s' 상품의 결제 예정일이 3일 남았습니다.",
-                    subscription.getProduct().getName()
-            );
+            String productName = subscription.getProduct().getName();
+            String content = NotificationType.PAYMENT_REMINDER.createContent(productName);
 
             notificationService.createNotification(
                     subscription.getMember(),

--- a/src/main/java/subscribenlike/mogupick/notification/scheduler/NotificationScheduler.java
+++ b/src/main/java/subscribenlike/mogupick/notification/scheduler/NotificationScheduler.java
@@ -1,0 +1,46 @@
+package subscribenlike.mogupick.notification.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import subscribenlike.mogupick.notification.domain.NotificationType;
+import subscribenlike.mogupick.notification.service.NotificationService;
+import subscribenlike.mogupick.subscription.domain.Subscription;
+import subscribenlike.mogupick.subscription.repository.SubscriptionRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotificationScheduler {
+
+    private final NotificationService notificationService;
+    private final SubscriptionRepository subscriptionRepository;
+
+    @Scheduled(cron = "0 0 9 * * *")
+    public void sendPaymentReminderNotifications() {
+        log.info("결제 3일 전 알림 스케줄러를 시작합니다.");
+
+        LocalDate targetDate = LocalDate.now().plusDays(3);
+
+        List<Subscription> subscriptions = subscriptionRepository.findByNextPaymentDate(targetDate);
+
+        for (Subscription subscription : subscriptions) {
+            String content = String.format(
+                    "'%s' 상품의 결제 예정일이 3일 남았습니다.",
+                    subscription.getProduct().getName()
+            );
+
+            notificationService.createNotification(
+                    subscription.getMember(),
+                    NotificationType.PAYMENT_REMINDER,
+                    content,
+                    "/my-page/subscriptions"
+            );
+        }
+        log.info("총 {}개의 결제 3일 전 알림 생성을 완료했습니다.", subscriptions.size());
+    }
+}

--- a/src/main/java/subscribenlike/mogupick/notification/service/NotificationService.java
+++ b/src/main/java/subscribenlike/mogupick/notification/service/NotificationService.java
@@ -49,4 +49,15 @@ public class NotificationService {
 
         notification.read();
     }
+
+    public void deleteNotification(Long notificationId, Long memberId) {
+        Notification notification = notificationRepository.findById(notificationId)
+                .orElseThrow(() -> new NotificationException(NotificationErrorCode.NOTIFICATION_NOT_FOUND));
+
+        if (!notification.getMember().getId().equals(memberId)) {
+            throw new NotificationException(NotificationErrorCode.FORBIDDEN_READ_NOTIFICATION); // 권한 없음 예외 재사용
+        }
+
+        notificationRepository.delete(notification);
+    }
 }

--- a/src/main/java/subscribenlike/mogupick/notification/service/NotificationService.java
+++ b/src/main/java/subscribenlike/mogupick/notification/service/NotificationService.java
@@ -4,9 +4,15 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import subscribenlike.mogupick.member.domain.Member;
+import subscribenlike.mogupick.notification.common.exception.NotificationErrorCode;
+import subscribenlike.mogupick.notification.common.exception.NotificationException;
 import subscribenlike.mogupick.notification.domain.Notification;
 import subscribenlike.mogupick.notification.domain.NotificationType;
+import subscribenlike.mogupick.notification.dto.NotificationResponse;
 import subscribenlike.mogupick.notification.repository.NotificationRepository;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional
@@ -23,5 +29,24 @@ public class NotificationService {
                 .url(url)
                 .build();
         notificationRepository.save(notification);
+    }
+
+    @Transactional(readOnly = true)
+    public List<NotificationResponse> getNotifications(Long memberId) {
+        List<Notification> notifications = notificationRepository.findByMemberIdOrderByCreatedAtDesc(memberId);
+        return notifications.stream()
+                .map(NotificationResponse::new)
+                .collect(Collectors.toList());
+    }
+
+    public void readNotification(Long notificationId, Long memberId) {
+        Notification notification = notificationRepository.findById(notificationId)
+                .orElseThrow(() -> new NotificationException(NotificationErrorCode.NOTIFICATION_NOT_FOUND));
+
+        if (!notification.getMember().getId().equals(memberId)) {
+            throw new NotificationException(NotificationErrorCode.FORBIDDEN_READ_NOTIFICATION);
+        }
+
+        notification.read();
     }
 }

--- a/src/main/java/subscribenlike/mogupick/notification/service/NotificationService.java
+++ b/src/main/java/subscribenlike/mogupick/notification/service/NotificationService.java
@@ -1,0 +1,27 @@
+package subscribenlike.mogupick.notification.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import subscribenlike.mogupick.member.domain.Member;
+import subscribenlike.mogupick.notification.domain.Notification;
+import subscribenlike.mogupick.notification.domain.NotificationType;
+import subscribenlike.mogupick.notification.repository.NotificationRepository;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class NotificationService {
+
+    private final NotificationRepository notificationRepository;
+
+    public void createNotification(Member member, NotificationType type, String content, String url) {
+        Notification notification = Notification.builder()
+                .member(member)
+                .notificationType(type)
+                .content(content)
+                .url(url)
+                .build();
+        notificationRepository.save(notification);
+    }
+}

--- a/src/main/java/subscribenlike/mogupick/subscription/domain/Subscription.java
+++ b/src/main/java/subscribenlike/mogupick/subscription/domain/Subscription.java
@@ -5,7 +5,10 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import subscribenlike.mogupick.common.domain.BaseEntity;
+import subscribenlike.mogupick.member.domain.Member;
 import subscribenlike.mogupick.product.domain.Product;
+
+import java.time.LocalDate;
 
 @Entity
 @Getter
@@ -17,4 +20,10 @@ public class Subscription extends BaseEntity {
 
     @ManyToOne
     private Product product;
+
+    @ManyToOne
+    private Member member;
+
+    private LocalDate nextPaymentDate;
+
 }

--- a/src/main/java/subscribenlike/mogupick/subscription/repository/SubscriptionRepository.java
+++ b/src/main/java/subscribenlike/mogupick/subscription/repository/SubscriptionRepository.java
@@ -1,0 +1,12 @@
+package subscribenlike.mogupick.subscription.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import subscribenlike.mogupick.subscription.domain.Subscription;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface SubscriptionRepository extends JpaRepository<Subscription, Long> {
+
+    List<Subscription> findByNextPaymentDate(LocalDate nextPaymentDate);
+}


### PR DESCRIPTION
# 🚀 What’s this PR about?
- **작업 내용 요약:** 사용자가 자신의 알림 목록을 확인하고, 특정 알림을 '읽음' 상태로 변경하거나 삭제할 수 있는 API를 구현합니다.

# 🛠️ What’s been done?
- NotificationController 추가: 아래 세 가지 API 엔드포인트를 구현했습니다.
  - GET /api/v1/notifications: 내 알림 목록 조회
  - PATCH /api/v1/notifications/{notificationId}: 알림 읽음 처리
  - DELETE /api/v1/notifications/{notificationId}: 알림 삭제
- NotificationService 로직 추가: 알림 목록 조회, 읽음 처리 및 삭제 비즈니스 로직을 구현했습니다.
- DTO 및 전역 핸들링 추가: NotificationResponse DTO를 추가하고, Notification 도메인 전용 SuccessCode와 ErrorCode를 추가하여 응답 처리를 표준화했습니다.



# 🧪 Testing Details
- **테스트 코드 및 결과:** 
- 알림 목록 조회 (GET): Authorization 헤더에 유효한 토큰으로 요청 시, 200 OK 응답과 함께 스케줄러가 생성한 알림 목록이 정상적으로 반환되었습니다.
- 알림 읽음 처리 (PATCH): Authorization 헤더와 알림 ID를 사용하여 요청 시, 200 OK 응답을 받았습니다.
- 알림 삭제 (DELETE): Authorization 헤더와 알림 ID를 사용하여 요청 시, 200 OK 응답을 받았습니다. API 호출 후, DB에서 해당 알림 데이터가 실제로 삭제된 것을 확인했습니다.

API 호출 후, DB에서 해당 알림의 is_read 컬럼이 true로 변경되는 것을 확인했습니다.
<img width="1285" height="645" alt="스크린샷 2025-09-08 오전 3 12 20" src="https://github.com/user-attachments/assets/9aedb0ab-d012-47e1-bd81-5d0723078331" />

<img width="1282" height="333" alt="스크린샷 2025-09-08 오전 3 15 37" src="https://github.com/user-attachments/assets/15319082-ddda-4047-be0e-bba9a1d04ac8" />

<img width="1282" height="330" alt="스크린샷 2025-09-08 오전 3 46 54" src="https://github.com/user-attachments/assets/9d609e25-2961-441d-b42e-247f8e436883" />

# 👀 Checkpoints for Reviewers
- **리뷰 시 확인할 사항:** 
  - 확인이 필요한 부분 (ex. 코드 스타일, 로직 등)
  - 추가로 논의하고 싶은 주제나 우려 사항
  - 리뷰어의 의견을 듣고 싶은 내용

# 🎯 Related Issues
- closes #92 
- closes #94 
 
