### PR TITLE
refactor:  member, notification repository 조회 로직 리팩토링

### DIFF
--- a/src/main/java/subscribenlike/mogupick/auth/service/AuthService.java
+++ b/src/main/java/subscribenlike/mogupick/auth/service/AuthService.java
@@ -52,8 +52,7 @@ public class AuthService {
             throw new AuthException(AuthErrorCode.INVALID_REFRESH_TOKEN);
         }
 
-        Member member = memberRepository.findByRefreshToken(refreshToken)
-                .orElseThrow(() -> new AuthException(AuthErrorCode.USER_NOT_FOUND_FOR_TOKEN));
+        Member member = memberRepository.findByRefreshTokenOrThrow(refreshToken);
 
         GrantedAuthority authority = new SimpleGrantedAuthority(member.getRole().name());
         Authentication authentication = new UsernamePasswordAuthenticationToken(member.getEmail(), null, Collections.singleton(authority));
@@ -72,9 +71,7 @@ public class AuthService {
         }
 
         Map<String, Object> userAttributes = client.getOAuthUserAttributes(request.getAccessToken());
-
         OAuthAttributes attributes = OAuthAttributes.of(request.getProvider(), userAttributes);
-
         Member member = memberRepository.findByEmail(attributes.getEmail())
                 .orElseGet(() -> memberRepository.save(attributes.toEntity()));
 

--- a/src/main/java/subscribenlike/mogupick/member/repository/MemberRepository.java
+++ b/src/main/java/subscribenlike/mogupick/member/repository/MemberRepository.java
@@ -1,6 +1,10 @@
 package subscribenlike.mogupick.member.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import subscribenlike.mogupick.auth.common.exception.AuthErrorCode;
+import subscribenlike.mogupick.auth.common.exception.AuthException;
+import subscribenlike.mogupick.member.common.exception.MemberErrorCode;
+import subscribenlike.mogupick.member.common.exception.MemberException;
 import subscribenlike.mogupick.member.domain.Member;
 
 import java.util.Optional;
@@ -13,11 +17,16 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     default Member findByEmailOrThrow(String email) {
         return findByEmail(email)
-                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
     }
 
-    default Member findOrThrow(Long id) {
+    default Member getById(Long id) {
         return findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("not found"));
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+    }
+
+    default Member findByRefreshTokenOrThrow(String refreshToken) {
+        return findByRefreshToken(refreshToken)
+                .orElseThrow(() -> new AuthException(AuthErrorCode.USER_NOT_FOUND_FOR_TOKEN));
     }
 }

--- a/src/main/java/subscribenlike/mogupick/member/service/MemberService.java
+++ b/src/main/java/subscribenlike/mogupick/member/service/MemberService.java
@@ -3,8 +3,6 @@ package subscribenlike.mogupick.member.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import subscribenlike.mogupick.member.common.exception.MemberErrorCode;
-import subscribenlike.mogupick.member.common.exception.MemberException;
 import subscribenlike.mogupick.member.domain.Member;
 import subscribenlike.mogupick.member.dto.MemberResponse;
 import subscribenlike.mogupick.member.dto.MemberUpdateRequest;
@@ -18,17 +16,13 @@ public class MemberService {
     private final MemberRepository memberRepository;
 
     public MemberResponse getMemberInfo(String email) {
-        Member member = memberRepository.findByEmail(email)
-                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
-
+        Member member = memberRepository.findByEmailOrThrow(email);
         return new MemberResponse(member);
     }
 
     @Transactional
     public void updateNickname(String email, MemberUpdateRequest request) {
-        Member member = memberRepository.findByEmail(email)
-                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
-
+        Member member = memberRepository.findByEmailOrThrow(email);
         member.updateNickname(request.getNickname());
     }
 }

--- a/src/main/java/subscribenlike/mogupick/notification/repository/NotificationRepository.java
+++ b/src/main/java/subscribenlike/mogupick/notification/repository/NotificationRepository.java
@@ -1,6 +1,8 @@
 package subscribenlike.mogupick.notification.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import subscribenlike.mogupick.notification.common.exception.NotificationErrorCode;
+import subscribenlike.mogupick.notification.common.exception.NotificationException;
 import subscribenlike.mogupick.notification.domain.Notification;
 
 import java.util.List;
@@ -9,4 +11,8 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
 
     List<Notification> findByMemberIdOrderByCreatedAtDesc(Long memberId);
 
+    default Notification getById(Long id) {
+        return findById(id)
+                .orElseThrow(() -> new NotificationException(NotificationErrorCode.NOTIFICATION_NOT_FOUND));
+    }
 }

--- a/src/main/java/subscribenlike/mogupick/notification/service/NotificationService.java
+++ b/src/main/java/subscribenlike/mogupick/notification/service/NotificationService.java
@@ -40,24 +40,20 @@ public class NotificationService {
     }
 
     public void readNotification(Long notificationId, Long memberId) {
-        Notification notification = notificationRepository.findById(notificationId)
-                .orElseThrow(() -> new NotificationException(NotificationErrorCode.NOTIFICATION_NOT_FOUND));
+        Notification notification = notificationRepository.getById(notificationId);
 
         if (!notification.getMember().getId().equals(memberId)) {
             throw new NotificationException(NotificationErrorCode.FORBIDDEN_READ_NOTIFICATION);
         }
-
         notification.read();
     }
 
     public void deleteNotification(Long notificationId, Long memberId) {
-        Notification notification = notificationRepository.findById(notificationId)
-                .orElseThrow(() -> new NotificationException(NotificationErrorCode.NOTIFICATION_NOT_FOUND));
+        Notification notification = notificationRepository.getById(notificationId);
 
         if (!notification.getMember().getId().equals(memberId)) {
-            throw new NotificationException(NotificationErrorCode.FORBIDDEN_READ_NOTIFICATION); // 권한 없음 예외 재사용
+            throw new NotificationException(NotificationErrorCode.FORBIDDEN_READ_NOTIFICATION);
         }
-
         notificationRepository.delete(notification);
     }
 }


### PR DESCRIPTION
# 🚀 What’s this PR about?
- **작업 내용 요약:** Repository의 default 메소드로 통합하여 코드의 일관성과 유지보수성을 보완했습니다

# 🛠️ What’s been done?
- MemberRepository, NotificationRepository 등 각 도메인 Repository에 findBy...OrThrow() 또는 getById() 같은 default 메소드를 추가했습니다.
- AuthService, MemberService, NotificationService에서 기존의 orElseThrow() 로직을 모두 Repository의 default 메소드 호출로 교체하여 코드를 간소화했습니다.

# 🧪 Testing Details
- **테스트 코드 및 결과:** 작성한 테스트 코드와 주요 테스트 케이스를 설명하고, 통과된 테스트 결과를 요약해 주세요.
  - 테스트 커버리지 및 성공 여부
  - 추가적인 검증이 필요한 시나리오

# 👀 Checkpoints for Reviewers
- **리뷰 시 확인할 사항:** 
  - 확인이 필요한 부분 (ex. 코드 스타일, 로직 등)
  - 추가로 논의하고 싶은 주제나 우려 사항
  - 리뷰어의 의견을 듣고 싶은 내용

# 🎯 Related Issues
- closes #99 