### PR TITLE
feat: 배송 도메인, 이벤트 알림 구현

### DIFF
--- a/src/main/java/subscribenlike/mogupick/billing/service/PaymentService.java
+++ b/src/main/java/subscribenlike/mogupick/billing/service/PaymentService.java
@@ -11,6 +11,10 @@ import subscribenlike.mogupick.billing.domain.PaymentState;
 import subscribenlike.mogupick.billing.dto.PaymentStateResponse;
 import subscribenlike.mogupick.billing.repository.PaymentStateRepository;
 import subscribenlike.mogupick.billing.service.client.TossPaymentsClient;
+import subscribenlike.mogupick.member.domain.Member;
+import subscribenlike.mogupick.member.repository.MemberRepository;
+import subscribenlike.mogupick.notification.domain.NotificationType;
+import subscribenlike.mogupick.notification.service.NotificationService;
 
 import java.util.Map;
 import java.util.Optional;
@@ -22,6 +26,8 @@ public class PaymentService {
     private final TossPaymentsClient toss;
     private final BillingKeyService billingKeyService;
     private final PaymentStateRepository paymentStateRepository;
+    private final NotificationService notificationService;
+    private final MemberRepository memberRepository;
 
     @Transactional
     public PaymentStateResponse charge(String orderId, String customerKey, String orderName, int amount) {
@@ -48,6 +54,16 @@ public class PaymentService {
             }
             st.markApproved(paymentKey.toString());
             log.info("charge.approved orderId={} paymentKey={}", orderId, paymentKey);
+
+            Member member = memberRepository.findByEmailOrThrow(customerKey);
+            String content = NotificationType.PAYMENT_COMPLETED.createContent(orderName);
+            notificationService.createNotification(
+                    member,
+                    NotificationType.PAYMENT_COMPLETED,
+                    content,
+                    "/alert"
+            );
+
             return PaymentStateResponse.from(st);
         } catch (BillingException e) {
             st.markFailed(e.getMessage());

--- a/src/main/java/subscribenlike/mogupick/delivery/common/exception/DeliveryErrorCode.java
+++ b/src/main/java/subscribenlike/mogupick/delivery/common/exception/DeliveryErrorCode.java
@@ -1,0 +1,29 @@
+package subscribenlike.mogupick.delivery.common.exception;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import subscribenlike.mogupick.common.error.core.ErrorCode;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public enum DeliveryErrorCode implements ErrorCode {
+
+    DELIVERY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 배송 정보를 찾을 수 없습니다.");
+
+    public static final String PREFIX = "[DELIVERY ERROR] ";
+
+    private final HttpStatus status;
+    private final String rawMessage;
+
+    @Override
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getMessage() {
+        return PREFIX + rawMessage;
+    }
+}

--- a/src/main/java/subscribenlike/mogupick/delivery/common/exception/DeliveryException.java
+++ b/src/main/java/subscribenlike/mogupick/delivery/common/exception/DeliveryException.java
@@ -1,0 +1,9 @@
+package subscribenlike.mogupick.delivery.common.exception;
+
+import subscribenlike.mogupick.common.error.core.BaseException;
+
+public class DeliveryException extends BaseException {
+    public DeliveryException(DeliveryErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/subscribenlike/mogupick/delivery/common/success/DeliverySuccessCode.java
+++ b/src/main/java/subscribenlike/mogupick/delivery/common/success/DeliverySuccessCode.java
@@ -10,7 +10,8 @@ import subscribenlike.mogupick.common.success.SuccessCode;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public enum DeliverySuccessCode implements SuccessCode {
 
-    DELIVERY_STARTED_SUCCESS(HttpStatus.OK, "배송 시작 처리에 성공했습니다.");
+    DELIVERY_STARTED_SUCCESS(HttpStatus.OK, "배송 시작 처리에 성공했습니다."),
+    DELIVERY_COMPLETED_SUCCESS(HttpStatus.OK, "배송 완료 처리에 성공했습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/subscribenlike/mogupick/delivery/common/success/DeliverySuccessCode.java
+++ b/src/main/java/subscribenlike/mogupick/delivery/common/success/DeliverySuccessCode.java
@@ -1,0 +1,17 @@
+package subscribenlike.mogupick.delivery.common.success;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import subscribenlike.mogupick.common.success.SuccessCode;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public enum DeliverySuccessCode implements SuccessCode {
+
+    DELIVERY_STARTED_SUCCESS(HttpStatus.OK, "배송 시작 처리에 성공했습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/subscribenlike/mogupick/delivery/controller/DeliveryController.java
+++ b/src/main/java/subscribenlike/mogupick/delivery/controller/DeliveryController.java
@@ -1,0 +1,25 @@
+package subscribenlike.mogupick.delivery.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import subscribenlike.mogupick.common.success.SuccessResponse;
+import subscribenlike.mogupick.delivery.common.success.DeliverySuccessCode;
+import subscribenlike.mogupick.delivery.service.DeliveryService;
+
+@Tag(name = "Delivery (관리자용)", description = "배송 관리 API")
+@RestController
+@RequestMapping("/api/v1/deliveries")
+@RequiredArgsConstructor
+public class DeliveryController {
+
+    private final DeliveryService deliveryService;
+
+    @Operation(summary = "배송 시작 처리", description = "특정 배송 건의 상태를 '배송 시작'으로 변경하고 알림을 보냅니다.")
+    @PostMapping("/{deliveryId}/start")
+    public SuccessResponse<Void> startDelivery(@PathVariable Long deliveryId) {
+        deliveryService.startDelivery(deliveryId);
+        return SuccessResponse.from(DeliverySuccessCode.DELIVERY_STARTED_SUCCESS);
+    }
+}

--- a/src/main/java/subscribenlike/mogupick/delivery/controller/DeliveryController.java
+++ b/src/main/java/subscribenlike/mogupick/delivery/controller/DeliveryController.java
@@ -22,4 +22,11 @@ public class DeliveryController {
         deliveryService.startDelivery(deliveryId);
         return SuccessResponse.from(DeliverySuccessCode.DELIVERY_STARTED_SUCCESS);
     }
+
+    @Operation(summary = "배송 완료 처리", description = "특정 배송 건의 상태를 '배송 완료'로 변경하고 알림을 보냅니다.")
+    @PostMapping("/{deliveryId}/complete")
+    public SuccessResponse<Void> completeDelivery(@PathVariable Long deliveryId) {
+        deliveryService.completeDelivery(deliveryId);
+        return SuccessResponse.from(DeliverySuccessCode.DELIVERY_COMPLETED_SUCCESS);
+    }
 }

--- a/src/main/java/subscribenlike/mogupick/delivery/domain/Delivery.java
+++ b/src/main/java/subscribenlike/mogupick/delivery/domain/Delivery.java
@@ -1,0 +1,42 @@
+package subscribenlike.mogupick.delivery.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import subscribenlike.mogupick.common.domain.BaseEntity;
+import subscribenlike.mogupick.member.domain.Member;
+import subscribenlike.mogupick.product.domain.Product;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Delivery extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne
+    @JoinColumn(name = "product_id")
+    private Product product;
+
+    @Enumerated(EnumType.STRING)
+    private DeliveryStatus status;
+
+    @Builder
+    public Delivery(Member member, Product product) {
+        this.member = member;
+        this.product = product;
+        this.status = DeliveryStatus.PENDING;
+    }
+
+    public void start() {
+        this.status = DeliveryStatus.SHIPPED;
+    }
+}

--- a/src/main/java/subscribenlike/mogupick/delivery/domain/Delivery.java
+++ b/src/main/java/subscribenlike/mogupick/delivery/domain/Delivery.java
@@ -39,4 +39,8 @@ public class Delivery extends BaseEntity {
     public void start() {
         this.status = DeliveryStatus.SHIPPED;
     }
+
+    public void complete() {
+        this.status = DeliveryStatus.DELIVERED;
+    }
 }

--- a/src/main/java/subscribenlike/mogupick/delivery/domain/DeliveryStatus.java
+++ b/src/main/java/subscribenlike/mogupick/delivery/domain/DeliveryStatus.java
@@ -1,0 +1,8 @@
+package subscribenlike.mogupick.delivery.domain;
+
+public enum DeliveryStatus {
+    PENDING, // 배송 준비중
+    SHIPPED, // 배송 시작
+    DELIVERED, // 배송 완료
+    CANCELLED // 주문 취소
+}

--- a/src/main/java/subscribenlike/mogupick/delivery/repository/DeliveryRepository.java
+++ b/src/main/java/subscribenlike/mogupick/delivery/repository/DeliveryRepository.java
@@ -1,0 +1,14 @@
+package subscribenlike.mogupick.delivery.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import subscribenlike.mogupick.delivery.common.exception.DeliveryErrorCode;
+import subscribenlike.mogupick.delivery.common.exception.DeliveryException;
+import subscribenlike.mogupick.delivery.domain.Delivery;
+
+public interface DeliveryRepository extends JpaRepository<Delivery, Long> {
+
+    default Delivery getById(Long id) {
+        return findById(id)
+                .orElseThrow(() -> new DeliveryException(DeliveryErrorCode.DELIVERY_NOT_FOUND));
+    }
+}

--- a/src/main/java/subscribenlike/mogupick/delivery/service/DeliveryService.java
+++ b/src/main/java/subscribenlike/mogupick/delivery/service/DeliveryService.java
@@ -1,0 +1,33 @@
+package subscribenlike.mogupick.delivery.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import subscribenlike.mogupick.delivery.domain.Delivery;
+import subscribenlike.mogupick.delivery.repository.DeliveryRepository;
+import subscribenlike.mogupick.notification.domain.NotificationType;
+import subscribenlike.mogupick.notification.service.NotificationService;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class DeliveryService {
+
+    private final DeliveryRepository deliveryRepository;
+    private final NotificationService notificationService;
+
+    public void startDelivery(Long deliveryId) {
+        Delivery delivery = deliveryRepository.getById(deliveryId);
+
+        delivery.start();
+
+        String content = NotificationType.DELIVERY_STARTED.createContent(delivery.getProduct().getName());
+
+        notificationService.createNotification(
+                delivery.getMember(),
+                NotificationType.DELIVERY_STARTED,
+                content,
+                "/alert"
+        );
+    }
+}

--- a/src/main/java/subscribenlike/mogupick/delivery/service/DeliveryService.java
+++ b/src/main/java/subscribenlike/mogupick/delivery/service/DeliveryService.java
@@ -30,4 +30,19 @@ public class DeliveryService {
                 "/alert"
         );
     }
+
+    public void completeDelivery(Long deliveryId) {
+        Delivery delivery = deliveryRepository.getById(deliveryId);
+
+        delivery.complete();
+
+        String content = NotificationType.DELIVERY_COMPLETED.createContent(delivery.getProduct().getName());
+
+        notificationService.createNotification(
+                delivery.getMember(),
+                NotificationType.DELIVERY_COMPLETED,
+                content,
+                "/alert"
+        );
+    }
 }

--- a/src/main/java/subscribenlike/mogupick/global/config/SecurityConfig.java
+++ b/src/main/java/subscribenlike/mogupick/global/config/SecurityConfig.java
@@ -36,8 +36,25 @@ public class SecurityConfig {
                 .formLogin(form -> form.disable())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        // TODO: 개발 완료 후, 기존 인증 설정으로 변경.
-                        .requestMatchers("/**").permitAll()
+                                // swagger, 소셜 로그인/재발급 API 등은 인증 없이 누구나 접근 가능
+                                .requestMatchers(
+                                        "/swagger-ui/**",
+                                        "/v3/api-docs/**",
+                                        "/api/v1/auth/social-login",
+                                        "/api/v1/auth/reissue"
+                                ).permitAll()
+
+                                // '/members/me', '/notifications/**' 등은 인증된 사용자만 접근 가능
+                                .requestMatchers(
+                                        "/api/v1/members/me",
+                                        "/api/v1/notifications/**"
+                                ).authenticated()
+
+                                // 로그아웃도 인증된 사용자만 가능
+                                .requestMatchers("/api/v1/auth/logout").authenticated()
+
+                                // 위 경로 외 나머지 모든 요청은 허용
+                                .anyRequest().permitAll()
                 )
                 .addFilterBefore(new JwtAuthenticationFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class);
 

--- a/src/main/java/subscribenlike/mogupick/notification/domain/NotificationType.java
+++ b/src/main/java/subscribenlike/mogupick/notification/domain/NotificationType.java
@@ -10,6 +10,8 @@ public enum NotificationType {
     DELIVERY_STARTED("배송 시작 알림", "'%s' 상품의 배송이 시작되었습니다."),
     PAYMENT_REMINDER("결제 예정 알림", "'%s' 상품의 결제 예정일이 3일 남았습니다."),
     PAYMENT_COMPLETED("결제 완료 알림", "'%s' 상품 결제가 정상적으로 완료되었습니다."),
+    DELIVERY_COMPLETED("배송 완료 알림", "'%s' 상품의 배송이 완료되었습니다."),
+
     NEW_REVIEW("새로운 리뷰 알림", "'%s' 상품에 새로운 리뷰가 달렸습니다.");
 
     private final String description;

--- a/src/main/java/subscribenlike/mogupick/notification/scheduler/NotificationScheduler.java
+++ b/src/main/java/subscribenlike/mogupick/notification/scheduler/NotificationScheduler.java
@@ -35,7 +35,7 @@ public class NotificationScheduler {
                     subscription.getMember(),
                     NotificationType.PAYMENT_REMINDER,
                     content,
-                    "/my-page/subscriptions"
+                    "/alert"
             );
         }
         log.info("총 {}개의 결제 3일 전 알림 생성을 완료했습니다.", subscriptions.size());


### PR DESCRIPTION
# 🚀 What’s this PR about?
- **작업 내용 요약:** 배송 도메인의 기반을 구현하고, 이를 활용해 '결제 완료' 및 '배송 시작', '배송 완료' 시점에 사용자에게 알림을 보내는 기능을 연동합니다.

# 🛠️ What’s been done?
- 배송(Delivery) 도메인 구현:
  - Delivery, DeliveryStatus 등 관련 엔티티 및 Enum을 생성했습니다.
  - DeliveryRepository, DeliveryService, DeliveryController를 추가하여 배송 상태를 관리할 수 있는 기반을 마련했습니다.

- 이벤트 기반 알림 연동:
  - PaymentService: 결제가 성공적으로 완료되면 '결제 완료' 알림을 생성하도록 로직을 추가했습니다.
  - DeliveryService: 배송 상태가 '배송 시작', '배송 완료'로 변경되면 알림을 생성하도록 로직을 추가했습니다.

- 권한 기반 API 접근 제어:
  - SecurityConfig를 수정하여, 개발용으로 열어두었던 모든 경로(/**)에 대한 permitAll() 설정을 제거했습니다.
  - 로그인, Swagger 등 공개가 필요한 API는 permitAll()로, 내 정보/알림 조회, 로그아웃 등 인증이 필요한 API는 authenticated()로 보호하도록 규칙을 추가했습니다.

# 🧪 Testing Details
- **테스트 코드 및 결과:** 
<img width="1278" height="586" alt="스크린샷 2025-09-08 오후 8 55 13" src="https://github.com/user-attachments/assets/d9f0f0d9-3d0c-400c-9945-20d7859a26c8" />
<img width="1284" height="337" alt="image" src="https://github.com/user-attachments/assets/52be097b-b824-45a5-b1c9-5d74e8f9911b" />

결제 테스트 진행 되는데로 올리겠습니다.
# 👀 Checkpoints for Reviewers
- **리뷰 시 확인할 사항:** 
  - 확인이 필요한 부분 (ex. 코드 스타일, 로직 등)
  - 추가로 논의하고 싶은 주제나 우려 사항
  - 리뷰어의 의견을 듣고 싶은 내용

# 🎯 Related Issues
- closes #102 
